### PR TITLE
Correct sending async future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [dependencies]
-enr = { version = "0.1.0-alpha.6", features = ["libsecp256k1", "ed25519", "libp2p"] }
+enr = { version = "0.1.0-alpha.6", features = ["libsecp256k1", "ed25519"] }
 tokio = { version = "0.2.20", features = ["net", "stream", "time"] }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 libsecp256k1 = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
 name = "discv5"
-edition = "2018"
-version = "0.1.0-alpha"
-description = "Implementation of the p2p discv5 discovery protocol"
 authors = ["Age Manning <Age@AgeManning.com>"]
+edition = "2018"
+version = "0.1.0-alpha.1"
+description = "Implementation of the p2p discv5 discovery protocol"
 license = "MIT"
 repository = "https://github.com/sigp/discv5"
 readme = "./README.md"
 keywords = ["peer-to-peer", "libp2p", "networking", "discovery", "discv5"]
 categories = ["network-programming", "asynchronous"]
+exclude = [
+	".gitignore",
+	".github/*"
+]
 
 [dependencies]
 enr = { version = "0.1.0-alpha.5", features = ["libsecp256k1", "ed25519", "libp2p"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["peer-to-peer", "libp2p", "networking", "discovery", "discv5"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-enr = { version = "0.1.0-alpha.5", features = ["libsecp256k1", "ed25519"] }
+enr = { version = "0.1.0-alpha.5", features = ["libsecp256k1", "ed25519", "libp2p"] }
 tokio = { version = "0.2.20", features = ["net", "stream", "time"] }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 libsecp256k1 = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 enr = { version = "0.1.0-alpha.5", features = ["libsecp256k1", "ed25519"] }
-tokio = { version = "0.2.19", features = ["time", "stream"] }
+tokio = { version = "0.2.20", features = ["net", "stream", "time"] }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 libsecp256k1 = "0.3.5"
 futures = "0.3.4"
@@ -27,7 +27,6 @@ fnv = "1.0.6"
 arrayvec = "0.5.1"
 digest = "0.8.1"
 rand = "0.7.3"
-async-std = "1.5.0"
 net2 = "0.2.33"
 smallvec = "1.4.0"
 
@@ -35,6 +34,6 @@ smallvec = "1.4.0"
 quickcheck = "0.9.2"
 env_logger = "0.7.1"
 simple_logger = "1.6.0"
-tokio = { version = "0.2.19", features = ["time", "rt-threaded", "macros"] }
+tokio = { version = "0.2.20", features = ["time", "rt-threaded", "macros"] }
 rand_xorshift = "0.2.0"
 rand_core = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [dependencies]
-enr = { version = "0.1.0-alpha.5", features = ["libsecp256k1", "ed25519", "libp2p"] }
+enr = { version = "0.1.0-alpha.6", features = ["libsecp256k1", "ed25519", "libp2p"] }
 tokio = { version = "0.2.20", features = ["net", "stream", "time"] }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 libsecp256k1 = "0.3.5"

--- a/README.md
+++ b/README.md
@@ -78,16 +78,17 @@ async fn main() {
     let target_random_node_id = enr::NodeId::random();
     discv5.find_node(target_random_node_id);
 
-   // poll the stream for the next FindNoeResult event
-   loop {
-        match discv5.next().await {
-            Some(Discv5Event::FindNodeResult { closer_peers, .. }) => {
-                println!("Query completed. Found {} peers", closer_peers.len());
-                break;
-            }
-            _ => {} // handle other discv5 events
-        }
-   }
+
+    // poll the stream for the next FindNoeResult event
+    while let Some(event) = discv5.next().await {
+        match event {
+             Discv5Event::FindNodeResult { closer_peers, .. } => {
+                 println!("Query completed. Found {} peers", closer_peers.len());
+                 break;
+             }
+             _ => {} // handle other discv5 events
+         }
+    }
 }
 ```
 
@@ -106,7 +107,7 @@ This protocol is split into three main sections/layers:
  undergoes a handshake, which results in a [`Session`]. [`Session`]'s are established when
  needed and get dropped after a timeout. This section manages the creation and maintenance of
  sessions between nodes. It is realised by the [`SessionService`] struct.
- * Behaviour - This section contains the protocol-level logic. In particular it manages the
+ * Application - This section contains the protocol-level logic. In particular it manages the
  routing table of known ENR's, topic registration/advertisement and performs various queries
  such as peer discovery. This section is realised by the [`Discv5`] struct.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@ impl Default for Discv5Config {
     }
 }
 
+#[derive(Debug)]
 pub struct Discv5ConfigBuilder {
     config: Discv5Config,
 }
@@ -144,7 +145,7 @@ impl Discv5ConfigBuilder {
 }
 
 impl std::fmt::Debug for Discv5Config {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut builder = f.debug_struct("Discv5Config");
         let _ = builder.field("request_timeout", &self.request_timeout);
         let _ = builder.field("query_timeout", &self.query_timeout);

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -24,7 +24,6 @@ use crate::rpc;
 use crate::service::MAX_PACKET_SIZE;
 use crate::session_service::{SessionEvent, SessionService};
 use crate::Discv5Config;
-use async_std::prelude::*;
 use enr::{CombinedKey, Enr as RawEnr, EnrError, EnrKey, NodeId};
 use fnv::FnvHashMap;
 use futures::prelude::*;

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -21,8 +21,8 @@ use crate::query_pool::{
     FindNodeQueryConfig, PredicateQueryConfig, QueryId, QueryPool, QueryPoolState, ReturnPeer,
 };
 use crate::rpc;
-use crate::service::MAX_PACKET_SIZE;
 use crate::session_service::{SessionEvent, SessionService};
+use crate::transport::MAX_PACKET_SIZE;
 use crate::Discv5Config;
 use enr::{CombinedKey, Enr as RawEnr, EnrError, EnrKey, NodeId};
 use fnv::FnvHashMap;
@@ -516,7 +516,7 @@ impl Discv5 {
         rpc_id: u64,
         distance: u64,
     ) {
-        let nodes: Vec<EntryRefView<NodeId, Enr>> = self
+        let nodes: Vec<EntryRefView<'_, NodeId, Enr>> = self
             .kbuckets
             .nodes_by_distance(distance)
             .into_iter()
@@ -936,7 +936,7 @@ impl Discv5 {
 impl Stream for Discv5 {
     type Item = Discv5Event;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
             // Process events from the session service
             while let Poll::Ready(Some(event)) = self.service.poll_next_unpin(cx) {

--- a/src/discv5/query_info.rs
+++ b/src/discv5/query_info.rs
@@ -29,7 +29,7 @@ pub enum QueryType {
 
 impl QueryInfo {
     /// Builds an RPC Request
-    pub fn into_rpc_request(
+    pub(crate) fn into_rpc_request(
         self,
         return_peer: &ReturnPeer<NodeId>,
     ) -> Result<Request, &'static str> {

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -289,7 +289,7 @@ async fn test_findnode_query() {
 
     let future = future::poll_fn(main);
 
-    if let Err(_) = timeout(Duration::from_millis(100), future).await {
+    if let Err(_) = timeout(Duration::from_millis(800), future).await {
         panic!("Future timed out");
     }
 }

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -203,7 +203,7 @@ async fn test_discovery_star_topology() {
     nodes.first_mut().unwrap().find_node(target_random_node_id);
     nodes.push(bootstrap_node);
 
-    let main = |cx: &mut Context| loop {
+    let main = |cx: &mut Context| {
         for node in nodes.iter_mut() {
             loop {
                 match node.poll_next_unpin(cx) {
@@ -221,6 +221,7 @@ async fn test_discovery_star_topology() {
                 }
             }
         }
+        Poll::Pending
     };
     future::poll_fn(main).await
 }
@@ -259,7 +260,7 @@ async fn test_findnode_query() {
         .take(total_nodes - 1)
         .collect();
 
-    let main = |cx: &mut Context| loop {
+    let main = |cx: &mut Context| {
         for node in nodes.iter_mut() {
             loop {
                 match node.poll_next_unpin(cx) {
@@ -283,6 +284,7 @@ async fn test_findnode_query() {
                 }
             }
         }
+        Poll::Pending
     };
 
     let future = future::poll_fn(main);
@@ -341,8 +343,8 @@ async fn test_updating_connection_on_ping() {
 }
 
 // The kbuckets table can have maximum 10 nodes in the same /24 subnet across all buckets
-#[test]
-fn test_table_limits() {
+#[tokio::test]
+async fn test_table_limits() {
     // this seed generates 12 node id's that are distributed accross buckets such that no more than
     // 2 exist in a single bucket.
     let mut keypairs = generate_deterministic_keypair(12, 9487);
@@ -381,8 +383,8 @@ fn test_table_limits() {
 }
 
 // Each bucket can have maximum 2 nodes in the same /24 subnet
-#[test]
-fn test_bucket_limits() {
+#[tokio::test]
+async fn test_bucket_limits() {
     let enr_key = CombinedKey::generate_secp256k1();
     let ip: IpAddr = "127.0.0.1".parse().unwrap();
     let enr = EnrBuilder::new("v4")
@@ -503,7 +505,7 @@ async fn test_predicate_search() {
         .find_enr_predicate(target_random_node_id, predicate, total_nodes);
     nodes.push(bootstrap_node);
 
-    let main = |cx: &mut Context| loop {
+    let main = |cx: &mut Context| {
         for node in nodes.iter_mut() {
             loop {
                 match node.poll_next_unpin(cx) {
@@ -513,19 +515,21 @@ async fn test_predicate_search() {
                             closer_peers.len(),
                             total_nodes,
                         );
+                        println!("Nodes expected to pass predicate search {}", num_nodes);
                         assert!(closer_peers.len() == num_nodes);
                         return Poll::Ready(());
                     }
                     Poll::Ready(_) => {}
-                    _ => break,
+                    Poll::Pending => break,
                 }
             }
         }
+        Poll::Pending
     };
 
     let future = future::poll_fn(main);
 
-    if let Err(_) = timeout(Duration::from_millis(100), future).await {
+    if let Err(_) = timeout(Duration::from_millis(500), future).await {
         panic!("Future timed out");
     }
 }

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -178,7 +178,7 @@ where
     }
 
     /// Returns an iterator over all the entries in the routing table.
-    pub fn iter(&mut self) -> impl Iterator<Item = EntryRefView<TNodeId, TVal>> {
+    pub fn iter(&mut self) -> impl Iterator<Item = EntryRefView<'_, TNodeId, TVal>> {
         let applied_pending = &mut self.applied_pending;
         self.buckets.iter_mut().flat_map(move |table| {
             if let Some(applied) = table.apply_pending() {
@@ -197,7 +197,7 @@ where
     /// Returns an iterator over all the entries in the routing table.
     /// Does not add pending node to kbucket to get an iterator which
     /// takes a reference instead of a mutable reference.
-    pub fn iter_ref(&self) -> impl Iterator<Item = EntryRefView<TNodeId, TVal>> {
+    pub fn iter_ref(&self) -> impl Iterator<Item = EntryRefView<'_, TNodeId, TVal>> {
         self.buckets.iter().flat_map(move |table| {
             table.iter().map(move |(n, status)| EntryRefView {
                 node: NodeRefView {

--- a/src/packet/auth_header.rs
+++ b/src/packet/auth_header.rs
@@ -88,7 +88,7 @@ impl Encodable for AuthResponse {
 }
 
 impl Decodable for AuthResponse {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         if !rlp.is_list() {
             return Err(DecoderError::RlpExpectedToBeList);
         }
@@ -124,7 +124,7 @@ impl Encodable for AuthHeader {
 }
 
 impl Decodable for AuthHeader {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         match rlp.item_count() {
             Ok(size) => {
                 if size != 5 {

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -2,10 +2,12 @@
 //!
 //! The [discv5 wire specification](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md) provides further information on UDP message packets as implemented in this module.
 //!
-//! The `Packet` struct defines all raw UDP message variants and implements the encoding/decoding
+//! A [`Packet`] defines all raw UDP message variants and implements the encoding/decoding
 //! logic.
 //!
 //! Note, that all message encryption/decryption is handled outside of this module.
+//!
+//! [`Packet`]: enum.Packet.html
 
 mod auth_header;
 

--- a/src/query_pool.rs
+++ b/src/query_pool.rs
@@ -23,8 +23,8 @@
 
 mod peers;
 
-pub use peers::closest::{FindNodeQuery, FindNodeQueryConfig};
-pub use peers::predicate::{PredicateQuery, PredicateQueryConfig};
+pub(crate) use peers::closest::{FindNodeQuery, FindNodeQueryConfig};
+pub(crate) use peers::predicate::{PredicateQuery, PredicateQueryConfig};
 pub use peers::{QueryState, ReturnPeer};
 
 use crate::kbucket::{Key, PredicateKey};
@@ -98,7 +98,7 @@ where
     }
 
     /// Adds a query to the pool that returns peers that satisfy a predicate.
-    pub fn add_predicate_query<I>(
+    pub(crate) fn add_predicate_query<I>(
         &mut self,
         config: PredicateQueryConfig,
         target: TTarget,
@@ -133,7 +133,7 @@ where
     }
 
     /// Polls the pool to advance the queries.
-    pub fn poll(&mut self) -> QueryPoolState<TTarget, TNodeId, TResult> {
+    pub fn poll(&mut self) -> QueryPoolState<'_, TTarget, TNodeId, TResult> {
         let now = Instant::now();
         let mut finished = None;
         let mut waiting = None;

--- a/src/query_pool/peers/predicate.rs
+++ b/src/query_pool/peers/predicate.rs
@@ -5,7 +5,7 @@ use std::collections::btree_map::{BTreeMap, Entry};
 use std::iter::FromIterator;
 use std::time::{Duration, Instant};
 
-pub struct PredicateQuery<TTarget, TNodeId, TResult> {
+pub(crate) struct PredicateQuery<TTarget, TNodeId, TResult> {
     /// The target key we are looking for
     target_key: Key<TTarget>,
 
@@ -30,20 +30,20 @@ pub struct PredicateQuery<TTarget, TNodeId, TResult> {
 
 /// Configuration for a `Query`.
 #[derive(Debug, Clone)]
-pub struct PredicateQueryConfig {
+pub(crate) struct PredicateQueryConfig {
     /// Allowed level of parallelism.
     ///
     /// The `α` parameter in the Kademlia paper. The maximum number of peers that a query
     /// is allowed to wait for in parallel while iterating towards the closest
     /// nodes to a target. Defaults to `3`.
-    pub parallelism: usize,
+    pub(crate) parallelism: usize,
 
     /// Number of results to produce.
     ///
     /// The number of closest peers that a query must obtain successful results
     /// for before it terminates. Defaults to the maximum number of entries in a
     /// single k-bucket, i.e. the `k` parameter in the Kademlia paper.
-    pub num_results: usize,
+    pub(crate) num_results: usize,
 
     /// The timeout for a single peer.
     ///
@@ -51,11 +51,11 @@ pub struct PredicateQueryConfig {
     /// window, the iterator considers the peer unresponsive and will not wait for
     /// the peer when evaluating the termination conditions, until and unless a
     /// result is delivered. Defaults to `10` seconds.
-    pub peer_timeout: Duration,
+    pub(crate) peer_timeout: Duration,
 }
 
 impl PredicateQueryConfig {
-    pub fn new_from_config(config: &Discv5Config) -> Self {
+    pub(crate) fn new_from_config(config: &Discv5Config) -> Self {
         Self {
             parallelism: config.query_parallelism,
             num_results: MAX_NODES_PER_BUCKET,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -6,19 +6,19 @@ use std::net::IpAddr;
 type TopicHash = [u8; 32];
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ProtocolMessage {
-    pub id: u64,
-    pub body: RpcType,
+pub(crate) struct ProtocolMessage {
+    pub(crate) id: u64,
+    pub(crate) body: RpcType,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum RpcType {
+pub(crate) enum RpcType {
     Request(Request),
     Response(Response),
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Request {
+pub(crate) enum Request {
     Ping { enr_seq: u64 },
     FindNode { distance: u64 },
     Ticket { topic: TopicHash },
@@ -27,7 +27,7 @@ pub enum Request {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Response {
+pub(crate) enum Response {
     Ping {
         enr_seq: u64,
         ip: IpAddr,
@@ -48,7 +48,7 @@ pub enum Response {
 
 impl Response {
     /// Determines if the response is a valid response to the given request.
-    pub fn match_request(&self, req: &Request) -> bool {
+    pub(crate) fn match_request(&self, req: &Request) -> bool {
         match self {
             Response::Ping { .. } => {
                 if let Request::Ping { .. } = req {
@@ -81,7 +81,7 @@ impl Response {
 }
 
 impl std::fmt::Display for RpcType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RpcType::Request(request) => write!(f, "{:?}", request),
             RpcType::Response(response) => write!(f, "{}", response),
@@ -90,7 +90,7 @@ impl std::fmt::Display for RpcType {
 }
 
 impl std::fmt::Display for Response {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Response::Ping { enr_seq, ip, port } => write!(
                 f,
@@ -124,13 +124,13 @@ impl std::fmt::Display for Response {
 }
 
 impl std::fmt::Display for ProtocolMessage {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Message: Id: {}, Body: {}", self.id, self.body)
     }
 }
 
 impl ProtocolMessage {
-    pub fn msg_type(&self) -> u8 {
+    pub(crate) fn msg_type(&self) -> u8 {
         match &self.body {
             RpcType::Request(request) => match request {
                 Request::Ping { .. } => 1,
@@ -149,7 +149,7 @@ impl ProtocolMessage {
     }
 
     /// Encodes a ProtocolMessage to RLP-encoded bytes.
-    pub fn encode(self) -> Vec<u8> {
+    pub(crate) fn encode(self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(10);
         let msg_type = self.msg_type();
         buf.push(msg_type);
@@ -250,7 +250,7 @@ impl ProtocolMessage {
         }
     }
 
-    pub fn decode(data: Vec<u8>) -> Result<Self, DecoderError> {
+    pub(crate) fn decode(data: Vec<u8>) -> Result<Self, DecoderError> {
         if data.len() < 3 {
             return Err(DecoderError::RlpIsTooShort);
         }

--- a/src/session/crypto.rs
+++ b/src/session/crypto.rs
@@ -28,7 +28,7 @@ type Key = [u8; KEY_LENGTH];
 /// Generates session and auth-response keys for a nonce and remote ENR. This currently only
 /// supports Secp256k1 signed ENR's. This returns four keys; initiator key, responder key, auth
 /// response key and the ephemeral public key.
-pub fn generate_session_keys(
+pub(crate) fn generate_session_keys(
     local_id: &NodeId,
     remote_enr: &Enr<CombinedKey>,
     id_nonce: &Nonce,
@@ -85,7 +85,7 @@ fn derive_key(
 }
 
 /// Derives the session keys for a public key type that matches the local keypair.
-pub fn derive_keys_from_pubkey(
+pub(crate) fn derive_keys_from_pubkey(
     local_key: &CombinedKey,
     local_id: &NodeId,
     remote_id: &NodeId,
@@ -115,7 +115,7 @@ pub fn derive_keys_from_pubkey(
 
 /// Generates a signature of a nonce given a keypair. This prefixes the `NONCE_PREFIX` to the
 /// signature.
-pub fn sign_nonce(
+pub(crate) fn sign_nonce(
     signing_key: &CombinedKey,
     nonce: &Nonce,
     ephem_pubkey: &[u8],
@@ -134,7 +134,7 @@ pub fn sign_nonce(
 }
 
 /// Verifies the authentication header nonce.
-pub fn verify_authentication_nonce(
+pub(crate) fn verify_authentication_nonce(
     remote_pubkey: &CombinedPublicKey,
     remote_ephem_pubkey: &[u8],
     nonce: &Nonce,
@@ -170,7 +170,7 @@ fn generate_signing_nonce(id_nonce: &Nonce, ephem_pubkey: &[u8]) -> Vec<u8> {
 
 /// Verifies the encoding and nonce signature given in the authentication header. If
 /// the header contains an updated ENR, it is returned.
-pub fn decrypt_authentication_header(
+pub(crate) fn decrypt_authentication_header(
     auth_resp_key: &Key,
     header: &AuthHeader,
 ) -> Result<AuthResponse, Discv5Error> {
@@ -186,7 +186,7 @@ pub fn decrypt_authentication_header(
 }
 
 /// Decrypt messages that are post-fixed with an authenticated MAC.
-pub fn decrypt_message(
+pub(crate) fn decrypt_message(
     key: &Key,
     nonce: AuthTag,
     message: &[u8],
@@ -216,7 +216,7 @@ pub fn decrypt_message(
 
 /// A wrapper around the underlying default AES_GCM implementation. This may be abstracted in the
 /// future.
-pub fn encrypt_message(
+pub(crate) fn encrypt_message(
     key: &Key,
     nonce: AuthTag,
     message: &[u8],

--- a/src/session_service/timed_sessions.rs
+++ b/src/session_service/timed_sessions.rs
@@ -19,7 +19,7 @@ use tokio::time::{delay_queue, DelayQueue};
 ///
 /// Sessions have an establishment timeout as
 /// well as lifetime.
-pub struct TimedSessions {
+pub(crate) struct TimedSessions {
     /// The sessions being established.
     sessions: HashMap<NodeId, (Session, delay_queue::Key)>,
     /// A queue indicating when a session has timed out.
@@ -29,7 +29,7 @@ pub struct TimedSessions {
 }
 
 impl TimedSessions {
-    pub fn new(session_establish_timeout: Duration) -> Self {
+    pub(crate) fn new(session_establish_timeout: Duration) -> Self {
         TimedSessions {
             sessions: HashMap::new(),
             timeouts: DelayQueue::new(),
@@ -37,31 +37,31 @@ impl TimedSessions {
         }
     }
 
-    pub fn insert(&mut self, node_id: NodeId, session: Session) {
+    pub(crate) fn insert(&mut self, node_id: NodeId, session: Session) {
         self.insert_at(node_id, session, self.session_establish_timeout);
     }
 
-    pub fn insert_at(&mut self, node_id: NodeId, session: Session, duration: Duration) {
+    pub(crate) fn insert_at(&mut self, node_id: NodeId, session: Session, duration: Duration) {
         let delay = self.timeouts.insert(node_id.clone(), duration);
 
         self.sessions.insert(node_id, (session, delay));
     }
 
-    pub fn get(&self, node_id: &NodeId) -> Option<&Session> {
+    pub(crate) fn get(&self, node_id: &NodeId) -> Option<&Session> {
         self.sessions.get(node_id).map(|&(ref v, _)| v)
     }
 
-    pub fn get_mut(&mut self, node_id: &NodeId) -> Option<&mut Session> {
+    pub(crate) fn get_mut(&mut self, node_id: &NodeId) -> Option<&mut Session> {
         self.sessions.get_mut(node_id).map(|(v, _)| v)
     }
 
-    pub fn update_timeout(&mut self, node_id: &NodeId, timeout: Duration) {
+    pub(crate) fn update_timeout(&mut self, node_id: &NodeId, timeout: Duration) {
         if let Some((_, key)) = self.sessions.get(node_id) {
             self.timeouts.reset(key, timeout);
         }
     }
 
-    pub fn remove(&mut self, node_id: &NodeId) {
+    pub(crate) fn remove(&mut self, node_id: &NodeId) {
         if let Some((_, delay_key)) = self.sessions.remove(node_id) {
             self.timeouts.remove(&delay_key);
         }
@@ -71,7 +71,7 @@ impl TimedSessions {
 impl Stream for TimedSessions {
     type Item = (NodeId, Session);
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.timeouts.poll_expired(cx) {
             Poll::Ready(Some(Ok(node_id))) => {
                 let node_id = node_id.into_inner();


### PR DESCRIPTION
# Overview

This updates the case where a future can be dropped when attempting to send a packet over the UDP socket. The major changes are:
- Remove async-std dependency and used tokio udp socket
- Use `poll_send_to()` for sending packets
- Updates documentation
- Version bump