### PR TITLE
Handle timeout error

### DIFF
--- a/src/session_service.rs
+++ b/src/session_service.rs
@@ -358,10 +358,10 @@ impl SessionService {
             warn!("Received a WHOAREYOU packet without having an established session.")
         })?;
 
-        // We should never receive a WHOAREYOU request, that matches an outgoing request AND have a
+        // We shouldn't receive a WHOAREYOU request, that matches an outgoing request AND have a
         // session that is in a WHOAREYOU_SENT state. If this is the case, drop the packet.
         if session.is_whoareyou_sent() {
-            error!("Received a WHOAREYOU packet whilst in a WHOAREYOU session state. Source: {}, node: {}", src, src_id);
+            warn!("Received a WHOAREYOU packet whilst in a WHOAREYOU session state. Source: {}, node: {}", src, src_id);
             return Ok(());
         }
 

--- a/src/session_service/timed_sessions.rs
+++ b/src/session_service/timed_sessions.rs
@@ -42,9 +42,14 @@ impl TimedSessions {
     }
 
     pub(crate) fn insert_at(&mut self, node_id: NodeId, session: Session, duration: Duration) {
-        let delay = self.timeouts.insert(node_id.clone(), duration);
+        if self.contains(&node_id) {
+            // update the timeout
+            self.update_timeout(&node_id, duration);
+        } else {
+            let delay = self.timeouts.insert(node_id.clone(), duration);
 
-        self.sessions.insert(node_id, (session, delay));
+            self.sessions.insert(node_id, (session, delay));
+        }
     }
 
     pub(crate) fn get(&self, node_id: &NodeId) -> Option<&Session> {
@@ -53,6 +58,11 @@ impl TimedSessions {
 
     pub(crate) fn get_mut(&mut self, node_id: &NodeId) -> Option<&mut Session> {
         self.sessions.get_mut(node_id).map(|(v, _)| v)
+    }
+
+    /// Returns true if the key exists, false otherwise.
+    pub(crate) fn contains(&self, node_id: &NodeId) -> bool {
+        self.sessions.contains_key(node_id)
     }
 
     pub(crate) fn update_timeout(&mut self, node_id: &NodeId, timeout: Duration) {


### PR DESCRIPTION
## Description

It is possible that multiple timeouts can be created. This leads to the possibility of not having a session or request exist in the timeout mapping when the delay_queue returns the object.

This PR prevents this from happening by updating a timeout if it exists rather than creating a new one.

This also downgrades an error warning.