### PR TITLE
Improved Session handling

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -934,10 +934,11 @@ impl Discv5 {
             }
         }
 
-        // report the node as being disconnected
-        debug!("Session dropped with Node: {}", node_id);
         self.connection_updated(node_id.clone(), None, NodeStatus::Disconnected);
-        self.connected_peers.remove(&node_id);
+        if self.connected_peers.remove(&node_id).is_some() {
+            // report the node as being disconnected
+            debug!("Session dropped with Node: {}", node_id);
+        }
     }
 }
 

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -666,6 +666,7 @@ impl Discv5 {
                 }
                 Err(_) => {
                     warn!("Sending request to node: {} failed", &node_id);
+                    self.connected_peers.remove(node_id);
                     if let Some(query_id) = query_id {
                         if let Some(query) = self.queries.get_mut(query_id) {
                             query.on_failure(&node_id);
@@ -880,7 +881,8 @@ impl Discv5 {
         self.connected_peers.insert(node_id, interval);
     }
 
-    /// A session could not be established or an RPC request timed-out (after a few retries).
+    /// A session could not be established or an RPC request timed-out (after a few retries, if
+    /// specified).
     fn rpc_failure(&mut self, node_id: NodeId, failed_rpc_id: RpcId) {
         let req = RpcRequest(failed_rpc_id, node_id);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ mod config;
 mod discv5;
 mod error;
 mod kbucket;
-mod packet;
+pub mod packet;
 mod query_pool;
 mod rpc;
 mod session;

--- a/src/session_service.rs
+++ b/src/session_service.rs
@@ -737,6 +737,7 @@ impl SessionService {
                     }
                     Packet::AuthMessage { .. } | Packet::Message { .. } => {
                         debug!("Message timed out with node: {}", node_id);
+                        sessions_ref.remove(&node_id);
                         events_ref.push_back(SessionEvent::RequestFailed(
                             node_id,
                             request.id().expect("Auth messages have an rpc id"),

--- a/src/session_service.rs
+++ b/src/session_service.rs
@@ -649,6 +649,9 @@ impl SessionService {
             self.events.push_back(SessionEvent::Established(
                 session.remote_enr().clone().expect("ENR exists"),
             ));
+            // update the session timeout
+            self.sessions
+                .update_timeout(&src_id, self.config.session_timeout);
             let _ = self.flush_messages(src, &src_id);
         }
 


### PR DESCRIPTION
This improves the Session management of peers.

Peers that do not respond to requests have their sessions dropped. 

Sessions that get created via returned messages have their timeouts extended.