### PR TITLE
Enable manual removal of nodes from routing table

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -194,6 +194,15 @@ impl Discv5 {
         Ok(())
     }
 
+    /// Removes a `node_id` from the routing table.
+    ///
+    /// This allows applications, for whatever reason, to remove nodes from the local routing
+    /// table. Returns `true` if the node was in the table and `false` otherwise.
+    pub fn remove_node(&mut self, node_id: &NodeId) -> bool {
+        let key = &kbucket::Key::from(*node_id);
+        self.kbuckets.remove(key)
+    }
+
     /// Returns the number of connected peers the service knows about.
     pub fn connected_peers(&self) -> usize {
         self.connected_peers.len()

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -162,6 +162,20 @@ where
         }
     }
 
+    /// Removes a node from the routing table. Returns `true` of the node existed.
+    pub fn remove(&mut self, key: &Key<TNodeId>) -> bool {
+        let index = BucketIndex::new(&self.local_key.distance(key));
+        if let Some(i) = index {
+            let bucket = &mut self.buckets[i.get()];
+            if let Some(applied) = bucket.apply_pending() {
+                self.applied_pending.push_back(applied)
+            }
+            bucket.remove(key)
+        } else {
+            false
+        }
+    }
+
     /// Returns an `Entry` for the given key, representing the state of the entry
     /// in the routing table.
     pub fn entry<'a>(&'a mut self, key: &'a Key<TNodeId>) -> Entry<'a, TNodeId, TVal> {

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -362,6 +362,16 @@ where
         }
     }
 
+    /// Removes a node from the bucket.
+    pub fn remove(&mut self, key: &Key<TNodeId>) -> bool {
+        if let Some(position) = self.position(key) {
+            self.nodes.remove(position.0);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Returns the status of the node at the given position.
     pub fn status(&self, pos: Position) -> NodeStatus {
         if self.first_connected_pos.map_or(false, |i| pos.0 >= i) {


### PR DESCRIPTION
Allows the application to manually remove nodes from the routing table