### PR TITLE
Expose underlying libraries for external use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ mod config;
 mod discv5;
 mod error;
 mod kbucket;
-mod packet;
+pub mod packet;
 mod query_pool;
 mod rpc;
 mod session;


### PR DESCRIPTION
Some extension projects require access to some underlying modules. This PR exposes these libraries.