### PR TITLE
Remove channel locking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "MIT"
 repository = "https://github.com/sigp/discv5"
@@ -18,7 +18,7 @@ exclude = [
 enr = { version = "0.1.0", features = ["libsecp256k1", "ed25519"] }
 tokio = { version = "0.2.21", features = ["net", "stream", "time", "sync"] }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
-libp2p-core = { version = "0.19.1", optional = true }
+libp2p-core = { version = "0.20.0", optional = true }
 multihash = { version = "0.11.2", optional = true }
 libsecp256k1 = "0.3.5"
 futures = "0.3.5"

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -176,7 +176,7 @@ pub struct Handler {
     /// Established sessions with peers.
     sessions: LruCache<NodeAddress, Session>,
     /// The channel that receives requests from the application layer.
-    inbound_channel: mpsc::Receiver<HandlerRequest>,
+    inbound_channel: mpsc::UnboundedReceiver<HandlerRequest>,
     /// The channel to send responses to the application layer.
     outbound_channel: mpsc::Sender<HandlerResponse>,
     /// The listening socket to filter out any attempted requests to self.
@@ -196,13 +196,13 @@ impl Handler {
         config: Discv5Config,
     ) -> (
         oneshot::Sender<()>,
-        mpsc::Sender<HandlerRequest>,
+        mpsc::UnboundedSender<HandlerRequest>,
         mpsc::Receiver<HandlerResponse>,
     ) {
         let (exit_sender, exit) = oneshot::channel();
         // create the channels to send/receive messages from the application
-        let (inbound_send, inbound_channel) = mpsc::channel(20);
-        let (outbound_channel, outbound_recv) = mpsc::channel(20);
+        let (inbound_send, inbound_channel) = mpsc::unbounded_channel();
+        let (outbound_channel, outbound_recv) = mpsc::channel(50);
 
         // Creates a SocketConfig to pass to the underlying UDP socket tasks.
 

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -44,14 +44,14 @@ async fn simple_session_message() {
         .build(&key2)
         .unwrap();
 
-    let (_exit_send, mut sender_handler, _) = Handler::spawn(
+    let (_exit_send, sender_handler, _) = Handler::spawn(
         arc_rw!(sender_enr.clone()),
         arc_rw!(key1),
         sender_enr.udp_socket().unwrap(),
         config.clone(),
     );
 
-    let (_exit_recv, mut recv_send, mut receiver_handler) = Handler::spawn(
+    let (_exit_recv, recv_send, mut receiver_handler) = Handler::spawn(
         arc_rw!(receiver_enr.clone()),
         arc_rw!(key2),
         receiver_enr.udp_socket().unwrap(),
@@ -67,8 +67,7 @@ async fn simple_session_message() {
         .send(HandlerRequest::Request(
             receiver_enr.into(),
             send_message.clone(),
-        ))
-        .await;
+        ));
 
     let receiver = async move {
         loop {
@@ -76,8 +75,7 @@ async fn simple_session_message() {
                 match message {
                     HandlerResponse::WhoAreYou(wru_ref) => {
                         let _ = recv_send
-                            .send(HandlerRequest::WhoAreYou(wru_ref, Some(sender_enr.clone())))
-                            .await;
+                            .send(HandlerRequest::WhoAreYou(wru_ref, Some(sender_enr.clone())));
                     }
                     HandlerResponse::Request(_, request) => {
                         assert_eq!(request, send_message);
@@ -122,14 +120,14 @@ async fn multiple_messages() {
         .build(&key2)
         .unwrap();
 
-    let (_exit_send, mut sender_handler, mut sender_handler_recv) = Handler::spawn(
+    let (_exit_send, sender_handler, mut sender_handler_recv) = Handler::spawn(
         arc_rw!(sender_enr.clone()),
         arc_rw!(key1),
         sender_enr.udp_socket().unwrap(),
         config.clone(),
     );
 
-    let (_exit_recv, mut recv_send, mut receiver_handler) = Handler::spawn(
+    let (_exit_recv, recv_send, mut receiver_handler) = Handler::spawn(
         arc_rw!(receiver_enr.clone()),
         arc_rw!(key2),
         receiver_enr.udp_socket().unwrap(),
@@ -157,8 +155,7 @@ async fn multiple_messages() {
         .send(HandlerRequest::Request(
             receiver_enr.clone().into(),
             send_message.clone(),
-        ))
-        .await;
+        ));
 
     let mut message_count = 0usize;
     let recv_send_message = send_message.clone();
@@ -173,8 +170,7 @@ async fn multiple_messages() {
                             .send(HandlerRequest::Request(
                                 receiver_enr.clone().into(),
                                 send_message.clone(),
-                            ))
-                            .await;
+                            ));
                     }
                 }
                 _ => continue,
@@ -187,8 +183,7 @@ async fn multiple_messages() {
             match receiver_handler.next().await {
                 Some(HandlerResponse::WhoAreYou(wru_ref)) => {
                     let _ = recv_send
-                        .send(HandlerRequest::WhoAreYou(wru_ref, Some(sender_enr.clone())))
-                        .await;
+                        .send(HandlerRequest::WhoAreYou(wru_ref, Some(sender_enr.clone())));
                 }
                 Some(HandlerResponse::Request(addr, request)) => {
                     assert_eq!(request, recv_send_message);
@@ -198,8 +193,7 @@ async fn multiple_messages() {
                         .send(HandlerRequest::Response(
                             addr,
                             Box::new(pong_response.clone()),
-                        ))
-                        .await;
+                        ));
                     if message_count == messages_to_send {
                         return;
                     }

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -63,11 +63,10 @@ async fn simple_session_message() {
         body: RequestBody::Ping { enr_seq: 1 },
     });
 
-    let _ = sender_handler
-        .send(HandlerRequest::Request(
-            receiver_enr.into(),
-            send_message.clone(),
-        ));
+    let _ = sender_handler.send(HandlerRequest::Request(
+        receiver_enr.into(),
+        send_message.clone(),
+    ));
 
     let receiver = async move {
         loop {
@@ -151,11 +150,10 @@ async fn multiple_messages() {
     let messages_to_send = 5usize;
 
     // sender to send the first message then await for the session to be established
-    let _ = sender_handler
-        .send(HandlerRequest::Request(
-            receiver_enr.clone().into(),
-            send_message.clone(),
-        ));
+    let _ = sender_handler.send(HandlerRequest::Request(
+        receiver_enr.clone().into(),
+        send_message.clone(),
+    ));
 
     let mut message_count = 0usize;
     let recv_send_message = send_message.clone();
@@ -166,11 +164,10 @@ async fn multiple_messages() {
                 Some(HandlerResponse::Established(_)) => {
                     // now the session is established, send the rest of the messages
                     for _ in 0..messages_to_send - 1 {
-                        let _ = sender_handler
-                            .send(HandlerRequest::Request(
-                                receiver_enr.clone().into(),
-                                send_message.clone(),
-                            ));
+                        let _ = sender_handler.send(HandlerRequest::Request(
+                            receiver_enr.clone().into(),
+                            send_message.clone(),
+                        ));
                     }
                 }
                 _ => continue,
@@ -189,11 +186,10 @@ async fn multiple_messages() {
                     assert_eq!(request, recv_send_message);
                     message_count += 1;
                     // required to send a pong response to establish the session
-                    let _ = recv_send
-                        .send(HandlerRequest::Response(
-                            addr,
-                            Box::new(pong_response.clone()),
-                        ));
+                    let _ = recv_send.send(HandlerRequest::Response(
+                        addr,
+                        Box::new(pong_response.clone()),
+                    ));
                     if message_count == messages_to_send {
                         return;
                     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -90,7 +90,7 @@ pub struct Service {
     ip_votes: Option<IpVote>,
 
     /// The channel to send messages to the handler.
-    handler_send: mpsc::Sender<HandlerRequest>,
+    handler_send: mpsc::UnboundedSender<HandlerRequest>,
 
     /// The channel to receive messages from the handler.
     handler_recv: mpsc::Receiver<HandlerResponse>,
@@ -98,6 +98,7 @@ pub struct Service {
     /// The exit channel to shutdown the handler.
     handler_exit: Option<oneshot::Sender<()>>,
 
+    /// The channel of messages sent by the controlling discv5 wrapper.
     discv5_recv: mpsc::Receiver<ServiceRequest>,
 
     exit: oneshot::Receiver<()>,
@@ -249,11 +250,11 @@ impl Service {
                         HandlerResponse::WhoAreYou(whoareyou_ref) => {
                             // check what our latest known ENR is for this node.
                             if let Some(known_enr) = self.find_enr(&whoareyou_ref.0.node_id) {
-                                self.handler_send.send(HandlerRequest::WhoAreYou(whoareyou_ref, Some(known_enr))).await.unwrap_or_else(|_| ());
+                                self.handler_send.send(HandlerRequest::WhoAreYou(whoareyou_ref, Some(known_enr))).unwrap_or_else(|_| ());
                             } else {
                                 // do not know of this peer
                                 debug!("NodeId unknown, requesting ENR. {}", whoareyou_ref.0);
-                                self.handler_send.send(HandlerRequest::WhoAreYou(whoareyou_ref, None)).await.unwrap_or_else(|_| ());
+                                self.handler_send.send(HandlerRequest::WhoAreYou(whoareyou_ref, None)).unwrap_or_else(|_| ());
                             }
                         }
                         HandlerResponse::RequestFailed(request_id, error) => {
@@ -405,7 +406,7 @@ impl Service {
                     debug!("Sending our ENR to node: {}", node_address);
                     self.handler_send
                         .send(HandlerRequest::Response(node_address, Box::new(response)))
-                        .await
+                       
                         .unwrap_or_else(|_| ());
                 } else {
                     self.send_nodes_response(node_address, id, distance).await;
@@ -450,7 +451,6 @@ impl Service {
                 debug!("Sending PONG response to {}", node_address);
                 self.handler_send
                     .send(HandlerRequest::Response(node_address, Box::new(response)))
-                    .await
                     .unwrap_or_else(|_| ());
             }
             _ => {} //TODO: Implement all RPC methods
@@ -723,7 +723,6 @@ impl Service {
             );
             self.handler_send
                 .send(HandlerRequest::Response(node_address, Box::new(response)))
-                .await
                 .unwrap_or_else(|_| ());
         } else {
             // build the NODES response
@@ -770,7 +769,6 @@ impl Service {
                         node_address.clone(),
                         Box::new(response),
                     ))
-                    .await
                     .unwrap_or_else(|_| ());
             }
         }
@@ -811,7 +809,6 @@ impl Service {
 
         self.handler_send
             .send(HandlerRequest::Request(contact, Box::new(request)))
-            .await
             .unwrap_or_else(|_| ());
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -406,7 +406,6 @@ impl Service {
                     debug!("Sending our ENR to node: {}", node_address);
                     self.handler_send
                         .send(HandlerRequest::Response(node_address, Box::new(response)))
-                       
                         .unwrap_or_else(|_| ());
                 } else {
                     self.send_nodes_response(node_address, id, distance).await;


### PR DESCRIPTION
It was previously possible to fill a channel between the service and the handler whilst the handler simultaneously filled the channel to the service. 

This scenario results in a deadlock as either service is awaiting the other to consume messages from the queue. 

This PR updates the service sending channel to be unbounded which frees it from waiting for the handler and allows it to freely consume handler requests at its leisure. 

The handler will still block if excessive messages are received from the network and await the service to complete its processing.