### PR TITLE
Alpha.7 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "MIT"
 repository = "https://github.com/sigp/discv5"
@@ -15,34 +15,34 @@ exclude = [
 ]
 
 [dependencies]
-enr = { version = "0.1.0", features = ["libsecp256k1", "ed25519"] }
+enr = { version = "0.1.1", features = ["libsecp256k1", "ed25519"] }
 tokio = { version = "0.2.21", features = ["net", "stream", "time", "sync"] }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
-libp2p-core = { version = "0.20.0", optional = true }
+libp2p-core = { version = "0.20.1", optional = true }
 multihash = { version = "0.11.2", optional = true }
 libsecp256k1 = "0.3.5"
 futures = "0.3.5"
 uint = { version = "0.8.3", default-features = false }
-log = "0.4.8"
+log = "0.4.11"
 rlp = "0.4.5"
 sha2 = "0.8.1"
 hkdf = "0.8.0"
-openssl = "0.10.29"
+openssl = "0.10.30"
 hex = "0.4.2"
 fnv = "1.0.7"
 arrayvec = "0.5.1"
 digest = "0.8.1"
 rand = "0.7.3"
 net2 = "0.2.34"
-smallvec = "1.4.0"
-parking_lot = "0.10.2"
+smallvec = "1.4.1"
+parking_lot = "0.11.0"
 lru_time_cache = "0.10.0"
 lazy_static = "1.4.0"
 
 [dev-dependencies]
 quickcheck = "0.9.2"
 env_logger = "0.7.1"
-hex-literal = "0.2.1"
+hex-literal = "0.3.0"
 simple_logger = "1.6.0"
 tokio = { version = "0.2.21", features = ["time", "rt-threaded", "macros"] }
 rand_xorshift = "0.2.0"

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -37,7 +37,6 @@
 
 use discv5::{enr, enr::CombinedKey, Discv5, Discv5ConfigBuilder};
 use futures::prelude::*;
-use hex_literal::*;
 use std::{
     net::{Ipv4Addr, SocketAddr},
     time::Duration,
@@ -65,7 +64,8 @@ async fn main() {
     };
 
     // A fixed key for testing
-    let raw_key = hex!("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    let raw_key =
+        hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291").unwrap();
     let secret_key = secp256k1::SecretKey::parse_slice(&raw_key).unwrap();
     let mut enr_key = CombinedKey::from(secret_key);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,7 @@ pub struct Discv5Config {
     /// The session timeout for each node. Default: 1 day.
     pub session_timeout: Duration,
 
-    /// The maximum number of established sessions to maintain. Default: 100.
+    /// The maximum number of established sessions to maintain. Default: 1000.
     pub session_cache_capacity: usize,
 
     /// Updates the local ENR IP and port based on PONG responses from peers. Default: true.
@@ -72,7 +72,7 @@ impl Default for Discv5Config {
             query_timeout: Duration::from_secs(60),
             request_retries: 1,
             session_timeout: Duration::from_secs(86400),
-            session_cache_capacity: 100,
+            session_cache_capacity: 1000,
             enr_update: true,
             enr_peer_update_min: 10,
             query_parallelism: 3,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -899,6 +899,12 @@ impl Handler {
 
             // Remove the expected response
             self.remove_expected_response(node_address.socket_addr.clone());
+
+            let auth_tag = request_call
+                .packet
+                .auth_tag()
+                .expect("No challenge packet in response");
+            self.active_requests_auth.remove(auth_tag);
             // The request matches report the response
             self.outbound_channel
                 .send(HandlerResponse::Response(


### PR DESCRIPTION
## Description

This updates the crate to alpha.7

This contains the following updates:

- A bug-fix (The Jonny Prevention Patch) which removes an active_request_auth mapping for requests that get responded to.
- Updates to dependencies to accommodate the ed25519 update
- Increase in the default size of the session cache, to prevent sessions expiring early and rapidly.
