### PR TITLE
Add feature to vendor openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ rand_core = "0.5.1"
 
 [features]
 libp2p = ["libp2p-core", "multihash"]
+openssl-vendored = ["openssl/vendored"]


### PR DESCRIPTION
Adds the `openssl-vendored` feature so that we can choose to statically link the openssl library. This will be nice for portable builds and dependency-minimization for Lighthouse.

Some other public crates that depend on openssl also do this (e.g., [here in reqwest](https://github.com/seanmonstar/reqwest/blob/dd8441fd23dae6ffb79b4cea2862e5bca0c59743/Cargo.toml#L34)).