### PR TITLE
Remove unnecessary async functions

### DIFF
--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -127,7 +127,7 @@ async fn test_updating_connection_on_ping() {
     );
 
     // Handle the ping and expect the disconnected Node to become connected
-    service.handle_rpc_response(response).await;
+    service.handle_rpc_response(response);
     let buckets = service.kbuckets.read();
     let node = buckets.iter_ref().next().unwrap();
     assert_eq!(node.status, NodeStatus::Connected);


### PR DESCRIPTION
Since updating to unbounded channels a number of async functions were left that no longer need to be async. 

This PR removes them. 