### PR TITLE
Add openssl-vendored feature again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ rand_core = "0.5.1"
 
 [features]
 libp2p = ["libp2p-core", "multihash"]
+openssl-vendored = ["openssl/vendored"]


### PR DESCRIPTION
This seems to have been lost in the latest version and it's preventing Lighthouse from compiling.