### PR TITLE
Message counter for AES-GCM Nonce

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -423,7 +423,7 @@ impl Handler {
         let tag = self.tag(&node_address.node_id);
 
         let packet = {
-            if let Some(session) = self.sessions.get(&node_address) {
+            if let Some(session) = self.sessions.get_mut(&node_address) {
                 // Encrypt the message and send
                 session
                     .encrypt_message(tag, &request.clone().encode())
@@ -453,7 +453,7 @@ impl Handler {
     async fn send_response(&mut self, node_address: NodeAddress, response: Response) {
         let tag = self.tag(&node_address.node_id);
         // Check for an established session
-        if let Some(session) = self.sessions.get(&node_address) {
+        if let Some(session) = self.sessions.get_mut(&node_address) {
             // Encrypt the message and send
             let packet = match session.encrypt_message(tag, &response.encode()) {
                 Ok(packet) => packet,

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -20,7 +20,7 @@ use sha2::{Digest, Sha256};
 use std::default::Default;
 
 pub const TAG_LENGTH: usize = 32;
-const AUTH_TAG_LENGTH: usize = 12;
+pub const AUTH_TAG_LENGTH: usize = 12;
 pub const MAGIC_LENGTH: usize = 32;
 pub const ID_NONCE_LENGTH: usize = 32;
 


### PR DESCRIPTION
Uses the number of messages sent per session as the first 32 bits of the Nonce used to encrypt packets. 

The remaining 64 bits are randomly generated. This ensures nonce's are not replayed per session, unless more than 2^32 messages are sent per session. Sessions expire in the order of days, making this limit virtually impossible to hit. 