### PR TITLE
Remove unnecessary verification

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -606,10 +606,7 @@ impl Handler {
                     .expect("Request call's are sanitized. Must have NodeAddress");
 
                 // Send the Auth response
-                trace!(
-                    "Sending Authentication response to node: {}",
-                    node_address
-                );
+                trace!("Sending Authentication response to node: {}", node_address);
                 request_call.packet = auth_packet.clone();
                 request_call.handshake_sent = true;
                 // Reinsert the request_call


### PR DESCRIPTION
In the function [handle_challenge](https://github.com/sigp/discv5/blob/839254cfb8fc3cd6bb3176393839793e31f0303d/src/handler/mod.rs#L512), both of the variables (enr, node_address) points to the same instance of NodeContact:
- enr comes from [the request_call.contact](https://github.com/sigp/discv5/blob/839254cfb8fc3cd6bb3176393839793e31f0303d/src/handler/mod.rs#L601)
- node_address comes from [the request_call.contact](https://github.com/sigp/discv5/blob/839254cfb8fc3cd6bb3176393839793e31f0303d/src/handler/mod.rs#L543-L546)

So I think that [the verification](https://github.com/sigp/discv5/blob/839254cfb8fc3cd6bb3176393839793e31f0303d/src/handler/mod.rs#L604) can be omitted. 💡 