### PR TITLE
Add logging by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ aes-gcm = "0.7.0"
 socket2 = "0.3.15"
 aes-ctr = "0.5.0"
 k256 = { version = "0.5.9", features = ["zeroize", "ecdh", "sha2"] }
-tracing = "0.1.21"
+tracing = { version = "0.1.21", features = ["log"] }
 tracing-subscriber = "0.2.13"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::needless_doctest_main)]
 //! An implementation of [Discovery V5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md).


### PR DESCRIPTION
Adds default `log` events for discv5 for backwards compatibility and log users.