### PR TITLE
Maintain session challenge

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::handler::Challenge;
 use rlp::DecoderError;
 
 #[derive(Debug)]
@@ -15,8 +16,8 @@ pub enum Discv5Error {
     InvalidRemotePublicKey,
     /// The secret key does not match the provided ENR.
     InvalidSecretKey,
-    /// An invalid signature was received.
-    InvalidSignature,
+    /// An invalid signature was received for a challenge.
+    InvalidChallengeSignature(Challenge),
     /// The Service channel has been closed early.
     ServiceChannelClosed,
     /// The discv5 service is not running.

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -763,7 +763,7 @@ impl Handler {
                 Err(Discv5Error::InvalidChallengeSignature(challenge)) => {
                     warn!(
                         "Authentication header contained invalid signature. Ignoring packet from: {}",
-                        node_address 
+                        node_address
                     );
                     // insert back the challenge
                     self.active_challenges.insert(node_address, challenge);

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -118,13 +118,14 @@ pub enum HandlerResponse {
 #[derive(Debug, Clone, PartialEq)]
 pub struct WhoAreYouRef(pub NodeAddress, MessageNonce);
 
-pub(crate) struct Challenge {
+#[derive(Debug)]
+pub struct Challenge {
     data: ChallengeData,
     remote_enr: Option<Enr>,
 }
 
-#[derive(Debug)]
 /// A request to a node that we are waiting for a response.
+#[derive(Debug)]
 pub(crate) struct RequestCall {
     contact: NodeContact,
     /// The raw discv5 packet sent.
@@ -758,6 +759,14 @@ impl Handler {
                         self.fail_session(&node_address, RequestError::InvalidRemoteEnr)
                             .await;
                     }
+                }
+                Err(Discv5Error::InvalidChallengeSignature(challenge)) => {
+                    warn!(
+                        "Authentication header contained invalid signature. Ignoring packet from: {}",
+                        node_address 
+                    );
+                    // insert back the challenge
+                    self.active_challenges.insert(node_address, challenge);
                 }
                 Err(e) => {
                     warn!(

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -42,6 +42,12 @@ pub type IdNonce = [u8; ID_NONCE_LENGTH];
 // This is the WHOAREYOU authenticated data.
 pub struct ChallengeData([u8; 63]);
 
+impl std::fmt::Debug for ChallengeData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
 impl std::convert::TryFrom<Vec<u8>> for ChallengeData {
     type Error = ();
 


### PR DESCRIPTION
If a signature is invalid for a specific handshake challenge, we maintain the challenge and allow the correct signature to be requested again