### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ exclude = [
 
 [dependencies]
 enr = { version = "0.4.0", features = ["k256", "ed25519"] }
-tokio = { version = "1.0", features = ["net", "sync", "macros"] }
-tokio-stream = "0.1.0"
-tokio-util = { version = "0.6.0", features = ["time"] }
-libp2p-core = { version = "0.25.1", optional = true }
+tokio = { version = "1.1", features = ["net", "sync", "macros"] }
+tokio-stream = "0.1.2"
+tokio-util = { version = "0.6.2", features = ["time"] }
+libp2p-core = { version = "0.27.0", optional = true }
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
 futures = "0.3.8"
 uint = { version = "0.8.5", default-features = false }
@@ -46,8 +46,8 @@ quickcheck = "0.9.2"
 env_logger = "0.8.2"
 hex-literal = "0.3.1"
 simple_logger = "1.11.0"
-tokio-util = { version = "0.6.0", features = ["time"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio-util = { version = "0.6.2", features = ["time"] }
+tokio = { version = "1.1", features = ["full"] }
 rand_xorshift = "0.2.0"
 rand_core = "0.5.1"
 


### PR DESCRIPTION
most important update is tokio-util to 0.6.2 because it fixes panics in `DelayQueue`