### PR TITLE
Add mitigation for ipv6 loop

### DIFF
--- a/src/query_pool/peers/closest.rs
+++ b/src/query_pool/peers/closest.rs
@@ -588,7 +588,12 @@ mod tests {
             // Determine if all peers have been contacted by the query. This _must_ be
             // the case if the query finished with fewer than the requested number
             // of results.
-            let all_contacted = query.closest_peers.values().all(|e| !matches!(e.state, QueryPeerState::NotContacted | QueryPeerState::Waiting { .. }));
+            let all_contacted = query.closest_peers.values().all(|e| {
+                !matches!(
+                    e.state,
+                    QueryPeerState::NotContacted | QueryPeerState::Waiting { .. }
+                )
+            });
 
             let target_key = query.target_key.clone();
             let num_results = query.config.num_results;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -206,7 +206,10 @@ impl Response {
         match self.body {
             ResponseBody::Pong { .. } => matches!(req, RequestBody::Ping { .. }),
             ResponseBody::Nodes { .. } => {
-                matches!(req, RequestBody::FindNode { .. } | RequestBody::TopicQuery { .. })
+                matches!(
+                    req,
+                    RequestBody::FindNode { .. } | RequestBody::TopicQuery { .. }
+                )
             }
             ResponseBody::Talk { .. } => matches!(req, RequestBody::Talk { .. }),
             ResponseBody::Ticket { .. } => matches!(req, RequestBody::RegisterTopic { .. }),


### PR DESCRIPTION
Attempt to avoid the loop described in https://github.com/sigp/lighthouse/issues/2215

The rationale for this change (credits to @pawanjay176) is that [`Enr::udp_socket`](https://docs.rs/enr/0.5.0/src/enr/lib.rs.html#369-376) only returns IPv4 addresses, whilst `IpVote::majority` can return IPv6 addresses. Therefore, when the majority address is an IPv6 address it will never be the case that `Some(majority_socket) != local_socket` and node will consistently attempt to update its address but never consider it successfully updated.

This PR explicitly ignores ipv6 addresses since it is my understanding that the rest of this code base is not ipv6-ready.

Note: I had to run `cargo fmt --all` to appease CI. You'll notice a couple of additional changes in the diff.