### PR TITLE
Auto-coerce to ping response to ipv4 when possible

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -437,9 +437,10 @@ impl Message {
                         ip.copy_from_slice(&ip_bytes);
                         let ipv6 = Ipv6Addr::from(ip);
                         // If the ipv6 is ipv4 compatible/mapped, simply return the ipv4.
-                        match ipv6.to_ipv4() {
-                            Some(ipv4) => IpAddr::V4(ipv4),
-                            None => IpAddr::V6(ipv6),
+                        if let Some(ipv4) = ipv6.to_ipv4() {
+                            IpAddr::V4(ipv4)
+                        } else {
+                            IpAddr::V6(ipv6)
                         }
                     }
                     _ => {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,6 +1,6 @@
 use enr::{CombinedKey, Enr};
 use rlp::{DecoderError, RlpStream};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use tracing::{debug, warn};
 
 type TopicHash = [u8; 32];
@@ -435,7 +435,12 @@ impl Message {
                     16 => {
                         let mut ip = [0u8; 16];
                         ip.copy_from_slice(&ip_bytes);
-                        IpAddr::from(ip)
+                        let ipv6 = Ipv6Addr::from(ip);
+                        // If the ipv6 is ipv4 compatible/mapped, simply return the ipv4.
+                        match ipv6.to_ipv4() {
+                            Some(ipv4) => IpAddr::V4(ipv4),
+                            None => IpAddr::V6(ipv6),
+                        }
                     }
                     _ => {
                         debug!("Ping Response has incorrect byte length for IP");


### PR DESCRIPTION
If a peer sends a ping response with an ipv6 address that is ipv4 compatible/mapped, then auto-convert to ipv4.

Related to https://github.com/sigp/discv5/pull/62