### PR TITLE
Feature update patches

### DIFF
--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -31,6 +31,7 @@
 #![allow(dead_code)]
 
 use super::*;
+use tracing::{debug, error};
 
 /// Maximum number of nodes in a bucket, i.e. the (fixed) `k` parameter.
 pub const MAX_NODES_PER_BUCKET: usize = 16;
@@ -348,7 +349,14 @@ where
                                 evicted: None,
                             })
                         }
-                        _ => unreachable!("Bucket is not full."), // Bucket filter should already be checked
+                        InsertResult::Full => unreachable!("Bucket cannot be full"),
+                        InsertResult::Pending { .. } | InsertResult::NodeExists => {
+                            error!("Bucket is not full or double node")
+                        }
+                        InsertResult::FailedFilter => debug!("Pending node failed filter"),
+                        InsertResult::TooManyIncoming => {
+                            debug!("Pending node failed incoming filter")
+                        }
                     }
                 }
             } else {

--- a/src/service.rs
+++ b/src/service.rs
@@ -359,10 +359,18 @@ impl Service {
         };
 
         let target_key: kbucket::Key<NodeId> = target.key();
-        let known_closest_peers: Vec<kbucket::Key<NodeId>> = {
+        let known_closest_peer_values = {
             let mut kbuckets = self.kbuckets.write();
-            kbuckets.closest_keys(&target_key).collect()
+            kbuckets.closest_values(&target_key)
         };
+
+        let mut known_closest_peers = Vec::new();
+        for closest in known_closest_peer_values {
+            // Add the known ENR's to the untrusted list
+            target.untrusted_enrs.push(closest.value);
+            // Add the key to the list for the query
+            known_closest_peers.push(closest.key);
+        }
         let query_config = FindNodeQueryConfig::new_from_config(&self.config);
         self.queries
             .add_findnode_query(query_config, target, known_closest_peers);
@@ -376,7 +384,7 @@ impl Service {
         predicate: Box<dyn Fn(&Enr) -> bool + Send>,
         callback: oneshot::Sender<Vec<Enr>>,
     ) {
-        let target = QueryInfo {
+        let mut target = QueryInfo {
             query_type: QueryType::FindNode(target_node),
             untrusted_enrs: Default::default(),
             distances_to_request: DISTANCES_TO_REQUEST_PER_PEER,
@@ -388,12 +396,18 @@ impl Service {
         // Map the TableEntry to an ENR.
         let kbucket_predicate = |e: &Enr| predicate(&e);
 
-        let known_closest_peers: Vec<kbucket::PredicateKey<NodeId>> = {
+        let known_closest_peer_values = {
             let mut kbuckets = self.kbuckets.write();
-            kbuckets
-                .closest_keys_predicate(&target_key, &kbucket_predicate)
-                .collect()
+            kbuckets.closest_values_predicate(&target_key, &kbucket_predicate)
         };
+
+        let mut known_closest_peers = Vec::<kbucket::PredicateKey<_>>::new();
+        for closest in known_closest_peer_values {
+            // Add the known ENR's to the untrusted list
+            target.untrusted_enrs.push(closest.value.clone());
+            // Add the key to the list for the query
+            known_closest_peers.push(closest.into());
+        }
 
         let mut query_config = PredicateQueryConfig::new_from_config(&self.config);
         query_config.num_results = num_nodes;
@@ -969,51 +983,59 @@ impl Service {
     }
 
     /// Processes discovered peers from a query.
-    fn discovered(&mut self, source: &NodeId, enrs: Vec<Enr>, query_id: Option<QueryId>) {
+    fn discovered(&mut self, source: &NodeId, mut enrs: Vec<Enr>, query_id: Option<QueryId>) {
         let local_id = self.local_enr.read().node_id();
-        let other_enr_iter = enrs.iter().filter(|p| p.node_id() != local_id);
+        enrs.retain(|enr| {
+            if enr.node_id() != local_id {
+                return false;
+            }
 
-        for enr_ref in other_enr_iter.clone() {
             // If any of the discovered nodes are in the routing table, and there contains an older ENR, update it.
             // If there is an event stream send the Discovered event
             if self.config.report_discovered_peers {
-                self.send_event(Discv5Event::Discovered(enr_ref.clone()));
+                self.send_event(Discv5Event::Discovered(enr.clone()));
             }
 
             // ignore peers that don't pass the table filter
-            if (self.config.table_filter)(&enr_ref) {
-                let key = kbucket::Key::from(enr_ref.node_id());
+            if (self.config.table_filter)(&enr) {
+                let key = kbucket::Key::from(enr.node_id());
 
                 // If the ENR exists in the routing table and the discovered ENR has a greater
                 // sequence number, perform some filter checks before updating the enr.
 
                 let must_update_enr = match self.kbuckets.write().entry(&key) {
-                    kbucket::Entry::Present(mut entry, _) => entry.value().seq() < enr_ref.seq(),
-                    kbucket::Entry::Pending(mut entry, _) => entry.value().seq() < enr_ref.seq(),
+                    kbucket::Entry::Present(mut entry, _) => entry.value().seq() < enr.seq(),
+                    kbucket::Entry::Pending(mut entry, _) => entry.value().seq() < enr.seq(),
                     _ => false,
                 };
 
                 if must_update_enr {
                     if let UpdateResult::Failed(reason) =
-                        self.kbuckets
-                            .write()
-                            .update_node(&key, enr_ref.clone(), None)
+                        self.kbuckets.write().update_node(&key, enr.clone(), None)
                     {
-                        self.peers_to_ping.remove(&enr_ref.node_id());
+                        self.peers_to_ping.remove(&enr.node_id());
                         debug!(
                             "Failed to update discovered ENR. Node: {}, Reason: {:?}",
                             source, reason
                         );
+
+                        false // Remove this peer from the discovered list
+                    } else {
+                        true // Keep this peer in the list
                     }
+                } else {
+                    true // We don't need to update ENR
                 }
+            } else {
+                false // Didn't pass the table filter
             }
-        }
+        });
 
         // if this is part of a query, update the query
         if let Some(query_id) = query_id {
             if let Some(query) = self.queries.get_mut(query_id) {
                 let mut peer_count = 0;
-                for enr_ref in other_enr_iter.clone() {
+                for enr_ref in enrs.iter() {
                     if !query
                         .target_mut()
                         .untrusted_enrs
@@ -1025,7 +1047,7 @@ impl Service {
                     peer_count += 1;
                 }
                 debug!("{} peers found for query id {:?}", peer_count, query_id);
-                query.on_success(source, &other_enr_iter.cloned().collect::<Vec<_>>())
+                query.on_success(source, &enrs)
             } else {
                 warn!("Response returned for ended query {:?}", query_id)
             }


### PR DESCRIPTION
This provides a number of corrections associated with the previous feature update.

Specifically, 
- Correctly handling of inserting pending peers into the routing table
- Adds initial ENRs into the untrusted list to account for cases when peers get removed from the routing table during a query.