### PR TITLE
Fix issues in `update_value`

### DIFF
--- a/src/kbucket/key.rs
+++ b/src/kbucket/key.rs
@@ -114,11 +114,12 @@ pub struct Distance(pub(super) U256);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::kbucket::bucket::tests::arbitrary_node_id;
     use quickcheck::*;
 
     impl Arbitrary for Key<NodeId> {
-        fn arbitrary<G: Gen>(_: &mut G) -> Key<NodeId> {
-            Key::from(NodeId::random())
+        fn arbitrary<G: Gen>(g: &mut G) -> Key<NodeId> {
+            Key::from(arbitrary_node_id(g))
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue in `KBucket::update_value` that caused two nodes to be removed rather than one when the filter check failed. It also updates the value of `first_connected_pos` so that it remains consistent in the case of a removal.

Testing has been expanded through a new `quickcheck` test which updates a value in the presence of a filter. I've also re-jigged some of the other quickcheck infra to make use of an `Arbitrary`-aware generator for `NodeId`, and refactored some of the common checks into `KBucket::check_invariants`.