### PR TITLE
Add getter function for node_address

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -80,6 +80,10 @@ impl Drop for TalkRequest {
 }
 
 impl TalkRequest {
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_address.node_id
+    }
+
     pub fn protocol(&self) -> &[u8] {
         &self.protocol
     }


### PR DESCRIPTION
This just adds a getter for node_address: NodeAddress in Impl TalkRequest.

This is useful if you want to send a talk request to a node that sent you one. Because you can find their ENR from it.