### PR TITLE
Update first connected pos in `KBucket::remove`

### DIFF
--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -626,7 +626,7 @@ where
     ///
     /// Returns `None` if the given key does not refer to an node in the
     /// bucket.
-    pub fn get(&mut self, key: &Key<TNodeId>) -> Option<&Node<TNodeId, TVal>> {
+    pub fn get(&self, key: &Key<TNodeId>) -> Option<&Node<TNodeId, TVal>> {
         self.nodes.iter().find(move |p| &p.key == key)
     }
 


### PR DESCRIPTION
Modify `KBucket::remove` so that it updates `first_connected_pos` and can no longer be used to violate the internal invariants of the bucket, i.e. ensure that `first_connected_pos` remains correct & in bounds.

I've also added a new quickcheck test that applies random actions from `KBucket`'s public interface in a random order. This should provide us with some reassurance that regardless of how `KBucket`'s methods are used by the rest of the crate, it will never panic. 

The only mutable methods from `KBucket` that are excluded from the new test are `pending_mut` and `get_mut`. The reason for their omission is that they're unrelated to the removal bug, and are limited in the damage they can do (they can't _remove_ bucket entries).
 