### PR TITLE
Emit warn log when no known_closest_peers found

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -436,9 +436,17 @@ impl Service {
             }
         }
 
-        let query_config = FindNodeQueryConfig::new_from_config(&self.config);
-        self.queries
-            .add_findnode_query(query_config, target, known_closest_peers);
+        if known_closest_peers.is_empty() {
+            warn!("No known_closest_peers found. Return empty result without sending query.");
+            if target.callback.send(vec![]).is_err() {
+                warn!("Failed to callback");
+            }
+            return;
+        } else {
+            let query_config = FindNodeQueryConfig::new_from_config(&self.config);
+            self.queries
+                .add_findnode_query(query_config, target, known_closest_peers);
+        }
     }
 
     /// Internal function that starts a query.
@@ -472,10 +480,18 @@ impl Service {
             }
         };
 
-        let mut query_config = PredicateQueryConfig::new_from_config(&self.config);
-        query_config.num_results = num_nodes;
-        self.queries
-            .add_predicate_query(query_config, target, known_closest_peers, predicate);
+        if known_closest_peers.is_empty() {
+            warn!("No known_closest_peers found. Return empty result without sending query.");
+            if target.callback.send(vec![]).is_err() {
+                warn!("Failed to callback");
+            }
+            return;
+        } else {
+            let mut query_config = PredicateQueryConfig::new_from_config(&self.config);
+            query_config.num_results = num_nodes;
+            self.queries
+                .add_predicate_query(query_config, target, known_closest_peers, predicate);
+        }
     }
 
     /// Returns an ENR if one is known for the given NodeId.


### PR DESCRIPTION
Added warn log to notice users that no known_closest_peers found. And I think it's better to return empty result immediately in the case.