### PR TITLE
Re-implement lru-time-cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ aes-gcm = "0.9.2"
 tracing = { version = "0.1.26", features = ["log"] }
 tracing-subscriber = "0.2.19"
 lru = "0.6.5"
+hashlink = "0.7.0"
 
 [dev-dependencies]
 rand_07 = { package = "rand", version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ digest = "0.9.0"
 rand = { version = "0.8.4", package = "rand" }
 smallvec = "1.6.1"
 parking_lot = "0.11.1"
-lru_time_cache = "0.11.11"
 lazy_static = "1.4.0"
 aes = { version = "0.7.4", features = ["ctr"] }
 aes-gcm = "0.9.2"

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -57,9 +57,9 @@ pub use crate::node_info::{NodeAddress, NodeContact};
 
 use crate::metrics::METRICS;
 
+use crate::lru_time_cache::LruTimeCache;
 use hashmap_delay::HashMapDelay;
 use session::Session;
-use crate::lru_time_cache::LruTimeCache;
 
 // The time interval to check banned peer timeouts and unban peers when the timeout has elapsed (in
 // seconds).
@@ -294,7 +294,10 @@ impl Handler {
                     active_requests_nonce_mapping: HashMap::new(),
                     pending_requests: HashMap::new(),
                     filter_expected_responses,
-                    sessions: LruTimeCache::new(config.session_timeout, Some(config.session_cache_capacity)),
+                    sessions: LruTimeCache::new(
+                        config.session_timeout,
+                        Some(config.session_cache_capacity),
+                    ),
                     active_challenges: LruTimeCache::new(config.request_timeout * 2, None),
                     inbound_channel,
                     outbound_channel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ mod error;
 mod executor;
 pub mod handler;
 mod kbucket;
+mod lru_time_cache;
 pub mod metrics;
 mod node_info;
 pub mod packet;

--- a/src/lru_time_cache.rs
+++ b/src/lru_time_cache.rs
@@ -195,7 +195,7 @@ mod tests {
         use std::thread::sleep;
         use std::time::Duration;
 
-        const TTL: Duration = Duration::from_millis(1);
+        const TTL: Duration = Duration::from_millis(100);
 
         #[test]
         fn get() {
@@ -225,6 +225,25 @@ mod tests {
 
             sleep(TTL);
             assert_eq!(0, cache.len());
+        }
+
+        #[test]
+        fn ttl() {
+            let mut cache = LruTimeCache::new(TTL, None);
+            cache.insert(1, 10);
+            sleep(TTL / 4);
+            cache.insert(2, 20);
+            sleep(TTL / 4);
+            cache.insert(3, 30);
+            sleep(TTL / 4);
+            cache.insert(4, 40);
+            sleep(TTL / 4);
+
+            assert_eq!(3, cache.len());
+            assert_eq!(None, cache.get(&1));
+            assert_eq!(Some(&20), cache.get(&2));
+            assert_eq!(Some(&30), cache.get(&3));
+            assert_eq!(Some(&40), cache.get(&4));
         }
     }
 }

--- a/src/lru_time_cache.rs
+++ b/src/lru_time_cache.rs
@@ -7,11 +7,16 @@ pub struct LruTimeCache<K, V> {
     /// The time elements remain in the cache.
     ttl: Duration,
     /// The max size of the cache.
-    capacity: Option<usize>,
+    capacity: usize,
 }
 
 impl<K: Clone + Eq + Hash, V> LruTimeCache<K, V> {
     pub fn new(ttl: Duration, capacity: Option<usize>) -> LruTimeCache<K, V>{
+        let capacity = if let Some(cap) = capacity {
+            cap
+        } else {
+            usize::MAX
+        };
         LruTimeCache {
             map: LinkedHashMap::new(),
             ttl,
@@ -24,10 +29,8 @@ impl<K: Clone + Eq + Hash, V> LruTimeCache<K, V> {
         let now = Instant::now();
         self.map.insert(key, (value, now));
 
-        if let Some(capacity) = self.capacity {
-            if self.map.len() > capacity {
-                self.map.pop_front();
-            }
+        if self.map.len() > self.capacity {
+            self.map.pop_front();
         }
     }
 

--- a/src/lru_time_cache.rs
+++ b/src/lru_time_cache.rs
@@ -1,0 +1,230 @@
+use hashlink::LinkedHashMap;
+use std::hash::Hash;
+use std::time::{Duration, Instant};
+
+pub struct LruTimeCache<K, V> {
+    map: LinkedHashMap<K, (V, Instant)>,
+    /// The time elements remain in the cache.
+    ttl: Duration,
+    /// The max size of the cache.
+    capacity: Option<usize>,
+}
+
+impl<K: Clone + Eq + Hash, V> LruTimeCache<K, V> {
+    pub fn new(ttl: Duration, capacity: Option<usize>) -> LruTimeCache<K, V>{
+        LruTimeCache {
+            map: LinkedHashMap::new(),
+            ttl,
+            capacity,
+        }
+    }
+
+    /// Inserts a key-value pair into the cache.
+    pub fn insert(&mut self, key: K, value: V) {
+        let now = Instant::now();
+        self.map.insert(key, (value, now));
+
+        if let Some(capacity) = self.capacity {
+            if self.map.len() > capacity {
+                self.map.pop_front();
+            }
+        }
+    }
+
+    /// Retrieves a reference to the value stored under `key`, or `None` if the key doesn't exist.
+    /// Also removes expired elements and updates the time.
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        self.get_mut(key).map(|value| &*value)
+    }
+
+    /// Retrieves a mutable reference to the value stored under `key`, or `None` if the key doesn't exist.
+    /// Also removes expired elements and updates the time.
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        let now = Instant::now();
+        self.remove_expired_values(now);
+
+        match self.map.raw_entry_mut().from_key(key) {
+            hashlink::linked_hash_map::RawEntryMut::Occupied(mut occupied) => {
+                occupied.get_mut().1 = now;
+                occupied.to_back();
+                Some(&mut occupied.into_mut().0)
+            }
+            hashlink::linked_hash_map::RawEntryMut::Vacant(_) => None,
+        }
+    }
+
+    /// Returns a reference to the value with the given `key`, if present and not expired, without
+    /// updating the timestamp.
+    pub fn peek(&self, key: &K) -> Option<&V> {
+        if let Some((value, time)) = self.map.get(key) {
+            return if *time + self.ttl >= Instant::now() {
+                Some(value)
+            } else {
+                None
+            };
+        }
+
+        None
+    }
+
+    /// Returns the size of the cache, i.e. the number of cached non-expired key-value pairs.
+    pub fn len(&mut self) -> usize {
+        self.remove_expired_values(Instant::now());
+        self.map.len()
+    }
+
+    /// Removes a key-value pair from the cache, returning the value at the key if the key
+    /// was previously in the map.
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.map.remove(key).map(|v| v.0)
+    }
+
+    /// Removes expired items from the cache.
+    fn remove_expired_values(&mut self, now: Instant) {
+        let mut expired_keys = vec![];
+
+        for (key, (_, time)) in self.map.iter_mut() {
+            if *time + self.ttl >= now {
+                break;
+            }
+            expired_keys.push(key.clone());
+        }
+
+        for k in expired_keys {
+            self.map.remove(&k);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lru_time_cache::LruTimeCache;
+    use std::time::Duration;
+
+    #[test]
+    fn insert() {
+        let mut cache = LruTimeCache::new(Duration::from_secs(10), None);
+
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
+
+        assert_eq!(Some(&10), cache.get(&1));
+        assert_eq!(Some(&20), cache.get(&2));
+        assert_eq!(Some(&30), cache.get(&3));
+    }
+
+    #[test]
+    fn capacity() {
+        let mut cache = LruTimeCache::new(Duration::from_secs(10), Some(2));
+
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        assert_eq!(2, cache.len());
+
+        cache.insert(3, 30);
+        assert_eq!(2, cache.len());
+        assert_eq!(Some(&20), cache.get(&2));
+        assert_eq!(Some(&30), cache.get(&3));
+    }
+
+    #[test]
+    fn get() {
+        let mut cache = LruTimeCache::new(Duration::from_secs(10), Some(2));
+
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        assert_eq!(Some(&10), cache.get(&1));
+
+        cache.insert(3, 30);
+        // `1` is alive as `get()` updates the timestamp.
+        assert_eq!(Some(&10), cache.get(&1));
+        // `2` is removed as `2` is oldest at the time `3` was inserted.
+        assert_eq!(None, cache.get(&2));
+    }
+
+    #[test]
+    fn get_mut() {
+        let mut cache = LruTimeCache::new(Duration::from_secs(10), None);
+
+        cache.insert(1, 10);
+        let v = cache.get_mut(&1).expect("should have value");
+        *v = 100;
+
+        assert_eq!(Some(&100), cache.get(&1));
+    }
+
+    #[test]
+    fn peek() {
+        let mut cache = LruTimeCache::new(Duration::from_secs(10), Some(2));
+
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        assert_eq!(Some(&10), cache.peek(&1));
+
+        cache.insert(3, 30);
+        // `1` is removed as `peek()` does not update the time.
+        assert_eq!(None, cache.peek(&1));
+        assert_eq!(Some(&20), cache.get(&2));
+    }
+
+    #[test]
+    fn len() {
+        let mut cache = LruTimeCache::new(Duration::from_secs(10), None);
+
+        assert_eq!(0, cache.len());
+
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
+        assert_eq!(3, cache.len());
+    }
+
+    #[test]
+    fn remove() {
+        let mut cache = LruTimeCache::new(Duration::from_secs(10), None);
+
+        cache.insert(1, 10);
+        assert_eq!(Some(10), cache.remove(&1));
+        assert_eq!(None, cache.get(&1));
+        assert_eq!(None, cache.remove(&1));
+    }
+
+    mod ttl {
+        use crate::lru_time_cache::LruTimeCache;
+        use std::thread::sleep;
+        use std::time::Duration;
+
+        const TTL: Duration = Duration::from_millis(1);
+
+        #[test]
+        fn get() {
+            let mut cache = LruTimeCache::new(TTL, None);
+            cache.insert(1, 10);
+            assert_eq!(Some(&10), cache.get(&1));
+
+            sleep(TTL);
+            assert_eq!(None, cache.get(&1));
+        }
+
+        #[test]
+        fn peek() {
+            let mut cache = LruTimeCache::new(TTL, None);
+            cache.insert(1, 10);
+            assert_eq!(Some(&10), cache.peek(&1));
+
+            sleep(TTL);
+            assert_eq!(None, cache.peek(&1));
+        }
+
+        #[test]
+        fn len() {
+            let mut cache = LruTimeCache::new(TTL, None);
+            cache.insert(1, 10);
+            assert_eq!(1, cache.len());
+
+            sleep(TTL);
+            assert_eq!(0, cache.len());
+        }
+    }
+}

--- a/src/lru_time_cache.rs
+++ b/src/lru_time_cache.rs
@@ -1,6 +1,8 @@
 use hashlink::LinkedHashMap;
-use std::hash::Hash;
-use std::time::{Duration, Instant};
+use std::{
+    hash::Hash,
+    time::{Duration, Instant},
+};
 
 pub struct LruTimeCache<K, V> {
     map: LinkedHashMap<K, (V, Instant)>,
@@ -11,7 +13,7 @@ pub struct LruTimeCache<K, V> {
 }
 
 impl<K: Clone + Eq + Hash, V> LruTimeCache<K, V> {
-    pub fn new(ttl: Duration, capacity: Option<usize>) -> LruTimeCache<K, V>{
+    pub fn new(ttl: Duration, capacity: Option<usize>) -> LruTimeCache<K, V> {
         let capacity = if let Some(cap) = capacity {
             cap
         } else {
@@ -195,8 +197,7 @@ mod tests {
 
     mod ttl {
         use crate::lru_time_cache::LruTimeCache;
-        use std::thread::sleep;
-        use std::time::Duration;
+        use std::{thread::sleep, time::Duration};
 
         const TTL: Duration = Duration::from_millis(100);
 


### PR DESCRIPTION
close https://github.com/sigp/discv5/issues/71

- use `hashlink::LinkedHashMap` as it's better to avoid to write unsafe code
- I have measured performance of LruTimeCache with the benchmark code below. LruTimeCache was `1,142 ns/iter`, while std::collections::HashMap was `664 ns/iter`.
  - It is good score
  - for your reference, I run [this benchmark]( https://github.com/maidsafe/lru_time_cache/issues/143#issue-756136904), lru_cache_sum was `101,426 ns/iter`

> test lru_time_cache::bench::hashmap_sum        ... bench:         664 ns/iter (+/- 195)
> test lru_time_cache::bench::lru_time_cache_sum ... bench:       1,142 ns/iter (+/- 187)


```rust

mod bench {
    extern crate test;

    use test::Bencher;

    use std::cell::RefCell;
    use std::collections::HashMap;

    const RANGE: usize = 32 * 1024;
    const FIND_TIMES: usize = 10;

    use rand::prelude::*;
    use crate::lru_time_cache::LruTimeCache;
    use std::time::Duration;

    #[bench]
    fn lru_time_cache_sum(b: &mut Bencher) {
        let mut lru = LruTimeCache::new(Duration::from_secs(10), Some(RANGE));
        for i in 0..RANGE {
            lru.insert(i, i);
        }
        let lru = RefCell::new(lru);
        b.iter(|| {
            let res: usize = (0..FIND_TIMES)
                .map(|_| {
                    *lru.borrow_mut()
                        .get(&thread_rng().gen_range(0..RANGE))
                        .unwrap_or(&0)
                })
                .sum();
            test::black_box(res);
        });
    }

    #[bench]
    fn hashmap_sum(b: &mut Bencher) {
        let mut map = HashMap::new();
        for i in 0..RANGE {
            map.insert(i, i);
        }
        b.iter(|| {
            let res: usize = (0..FIND_TIMES)
                .map(|_| *map.get(&thread_rng().gen_range(0..RANGE)).unwrap_or(&0))
                .sum();
            test::black_box(res);
        });
    }
}
```

(Could not add the benchmark code to this repo as benchmarking support is unstable.)