### PR TITLE
Remove mut self from find_enr()

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -284,7 +284,7 @@ impl Discv5 {
     }
 
     /// Returns an ENR if one is known for the given NodeId.
-    pub fn find_enr(&mut self, node_id: &NodeId) -> Option<Enr> {
+    pub fn find_enr(&self, node_id: &NodeId) -> Option<Enr> {
         // check if we know this node id in our routing table
         let key = kbucket::Key::from(*node_id);
         if let kbucket::Entry::Present(mut entry, _) = self.kbuckets.write().entry(&key) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -479,7 +479,7 @@ impl Service {
     }
 
     /// Returns an ENR if one is known for the given NodeId.
-    pub fn find_enr(&mut self, node_id: &NodeId) -> Option<Enr> {
+    pub fn find_enr(&self, node_id: &NodeId) -> Option<Enr> {
         // check if we know this node id in our routing table
         let key = kbucket::Key::from(*node_id);
         if let kbucket::Entry::Present(mut entry, _) = self.kbuckets.write().entry(&key) {


### PR DESCRIPTION
- Removed mut self from find_enr()

So I am making this PR because to my knowledge the mut self isn't required and it will work without mutability. I am not the most knowledgeable in Rust, but it does seem to be unnecessary correct me if I am wrong.

It would be nice to have this not mutable because then you can use it from an Arc reference of the Discv5 Impl.

@AgeManning 