### PR TITLE
Modify nodes_by_distances to take slice arg instead of Vec

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -234,7 +234,7 @@ impl Discv5 {
         if !distances.is_empty() {
             let mut kbuckets = self.kbuckets.write();
             for node in kbuckets
-                .nodes_by_distances(distances, self.config.max_nodes_response)
+                .nodes_by_distances(distances.as_slice(), self.config.max_nodes_response)
                 .into_iter()
                 .map(|entry| entry.node.value.clone())
             {

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -560,19 +560,19 @@ where
     /// Returns an iterator over the keys that are contained in a kbucket, specified by a log2 distance.
     pub fn nodes_by_distances(
         &mut self,
-        log2_distances: Vec<u64>,
+        log2_distances: &[u64],
         max_nodes: usize,
     ) -> Vec<EntryRefView<'_, TNodeId, TVal>> {
         let distances = log2_distances
-            .into_iter()
-            .filter(|&d| d > 0 && d <= (NUM_BUCKETS as u64))
+            .iter()
+            .filter(|&d| *d > 0 && *d <= (NUM_BUCKETS as u64))
             .collect::<Vec<_>>();
 
         // apply bending nodes
         for distance in &distances {
             // the log2 distance ranges from 1-256 and is always 1 more than the bucket index. For this
             // reason we subtract 1 from log2 distance to get the correct bucket index.
-            let bucket = &mut self.buckets[(distance - 1) as usize];
+            let bucket = &mut self.buckets[(*distance - 1) as usize];
             if let Some(applied) = bucket.apply_pending() {
                 self.applied_pending.push_back(applied)
             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -908,7 +908,7 @@ impl Service {
         if !distances.is_empty() {
             let mut kbuckets = self.kbuckets.write();
             for node in kbuckets
-                .nodes_by_distances(distances, self.config.max_nodes_response)
+                .nodes_by_distances(distances.as_slice(), self.config.max_nodes_response)
                 .into_iter()
                 .filter_map(|entry| {
                     if entry.node.key.preimage() != &node_address.node_id {


### PR DESCRIPTION
Modify `nodes_by_distances` method of `KBucketsTable` to take a slice argument for `log2_distances`.

I'm not sure whether we need to bump the version given it's marked as beta. Also, AFAIK we (trin) are the only consumers of the recently public `kbuckets` module API.