### PR TITLE
Prevent adding duplicate nodes

### DIFF
--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -601,7 +601,6 @@ where
         if matches!(insert_result, InsertResult::Inserted) && inserting_pending {
             self.pending = None
         }
-        }
         insert_result
     }
 


### PR DESCRIPTION
With filters enabled, it was possible (although unlikely) to add duplicate nodes to a bucket. 

This can happy via the following set of actions:

- The bucket becomes full
- A node (call it A) gets added to the pending state of the bucket
- A node gets removed from the bucket for updating state that is incompatible with a filter, making the bucket no longer full
- The node A can then get inserted into the bucket from a new RPC message (as the table is no longer full). This happens before the pending time. 
- The pending timeout expires and the pending node (A) gets inserted in the table as a duplicate

This PR drops the pending node if it already exists in the bucket.