### PR TITLE
Add getter for RequestId of TalkRequest

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -80,6 +80,10 @@ impl Drop for TalkRequest {
 }
 
 impl TalkRequest {
+    pub fn id(&self) -> &RequestId {
+        &self.id
+    }
+
     pub fn node_id(&self) -> &NodeId {
         &self.node_address.node_id
     }


### PR DESCRIPTION
Expose the `RequestId` of a `TalkRequest`.

Motivation: Allow protocols built on top of `discv5` to access request IDs of `TalkRequest` for e.g. logging.