### PR TITLE
Public kbuckets access and bucket index

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -283,6 +283,11 @@ impl Discv5 {
         self.local_enr.read().clone()
     }
 
+    /// Returns the routing table of the discv5 service
+    pub fn kbuckets(&self) -> KBucketsTable<NodeId, Enr> {
+        self.kbuckets.read().clone()
+    }
+
     /// Returns an ENR if one is known for the given NodeId.
     pub fn find_enr(&self, node_id: &NodeId) -> Option<Enr> {
         // check if we know this node id in our routing table

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -516,6 +516,11 @@ where
         })
     }
 
+    /// Returns an iterator over all the buckets in the routing table
+    pub fn buckets_iter(&self) -> impl Iterator<Item = &KBucket<TNodeId, TVal>> {
+        self.buckets.iter()
+    }
+
     /// Returns an iterator over all the entries in the routing table to give to a table filter.
     ///
     /// This differs from the regular iterator as it doesn't take ownership of self and doesn't try
@@ -698,6 +703,12 @@ where
         } else {
             None
         }
+    }
+
+    /// Returns a bucket index given the key. Returns None if bucket index does not exist.
+    pub fn get_index(&self, key: &Key<TNodeId>) -> Option<usize> {
+        let index = BucketIndex::new(&self.local_key.distance(key));
+        index.map(|i| i.get())
     }
 }
 


### PR DESCRIPTION
In [Trin](https://github.com/ethereum/trin), we are manually managing the overlay instance of the routing table (`KBucketsTable<TNodeId, TVal: Eq>`) and the buckets (`Vec<KBucket<TNodeId, TVal>>`). For example, we are using a custom bucket refresh lookup algorithm which is first picking buckets with index 239-255, then we select a target bucket and generate a random NodeID falling in the target bucket range. (For more details please check this PR: https://github.com/ethereum/trin/pull/213)

To make this possible, we need public access to the `buckets`  field in `KBucketsTable` and a way to check if a random NodeIi falls in a target bucket index (mainly for testing purposes).

Please advise what would be the most convenient way to accomplish this, happy to tweak this PR to meet maintainers' preferences.