### PR TITLE
force node contact to have a contactable node address

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -25,6 +25,7 @@ use crate::{
 use enr::{CombinedKey, EnrError, EnrKey, NodeId};
 use parking_lot::RwLock;
 use std::{
+    convert::TryInto,
     future::Future,
     net::SocketAddr,
     sync::Arc,
@@ -315,7 +316,7 @@ impl Discv5 {
         PERMIT_BAN_LIST.write().ban_nodes.remove(node_id);
     }
 
-    /// Permits a node, allowing the node to bypass the packet filter.  
+    /// Permits a node, allowing the node to bypass the packet filter.
     pub fn permit_node(&self, node_id: &NodeId) {
         PERMIT_BAN_LIST.write().permit_nodes.insert(*node_id);
     }
@@ -336,7 +337,7 @@ impl Discv5 {
         PERMIT_BAN_LIST.write().ban_ips.remove(ip);
     }
 
-    /// Permits an IP, allowing the all packets from the IP to bypass the packet filter.  
+    /// Permits an IP, allowing the all packets from the IP to bypass the packet filter.
     pub fn permit_ip(&self, ip: std::net::IpAddr) {
         PERMIT_BAN_LIST.write().permit_ips.insert(ip);
     }
@@ -454,15 +455,17 @@ impl Discv5 {
         protocol: Vec<u8>,
         request: Vec<u8>,
     ) -> impl Future<Output = Result<Vec<u8>, RequestError>> + 'static {
-        // convert the ENR to a node_contact.
-        let node_contact = NodeContact::from(enr);
-
         // the service will verify if this node is contactable, we just send it and
         // await a response.
         let (callback_send, callback_recv) = oneshot::channel();
         let channel = self.clone_channel();
 
         async move {
+            // convert the ENR to a node_contact.
+            let node_contact: NodeContact = match enr.try_into() {
+                Ok(node_contact) => node_contact,
+                Err(e) => return Err(RequestError::InvalidEnr(e.into())),
+            };
             let channel = channel.map_err(|_| RequestError::ServiceNotStarted)?;
 
             let event = ServiceRequest::Talk(node_contact, protocol, request, callback_send);

--- a/src/handler/crypto/mod.rs
+++ b/src/handler/crypto/mod.rs
@@ -342,7 +342,13 @@ mod tests {
         let node2_key = CombinedKey::generate_secp256k1();
 
         let node1_enr = EnrBuilder::new("v4").build(&node1_key).unwrap();
-        let node2_enr = EnrBuilder::new("v4").build(&node2_key).unwrap();
+        let node2_port = 5003;
+        let node2_ip = "127.0.0.1".parse().unwrap();
+        let node2_enr = EnrBuilder::new("v4")
+            .ip(node2_ip)
+            .udp(node2_port)
+            .build(&node2_key)
+            .unwrap();
 
         let challenge_data = vec![1; 63];
         let challenge_data = ChallengeData::try_from(challenge_data.as_slice()).unwrap();

--- a/src/handler/crypto/mod.rs
+++ b/src/handler/crypto/mod.rs
@@ -349,7 +349,7 @@ mod tests {
 
         let (key1, key2, pk) = generate_session_keys(
             &node1_enr.node_id(),
-            &node2_enr.clone().into(),
+            &node2_enr.clone().try_into().unwrap(),
             &challenge_data,
         )
         .unwrap();

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -121,7 +121,6 @@ impl std::convert::TryFrom<Multiaddr> for NodeContact {
 
 impl std::fmt::Display for NodeContact {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO: maybe the enr too?
         write!(f, "addr: {:?}", self.node_address())
     }
 }

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -152,8 +152,8 @@ async fn test_updating_connection_on_ping() {
         },
     };
 
-    let node_contact = NodeContact::Enr(Box::new(enr2));
-    let expected_return_addr = node_contact.node_address().unwrap();
+    let node_contact: NodeContact = enr2.try_into().unwrap();
+    let expected_return_addr = node_contact.node_address();
 
     service.active_requests.insert(
         RequestId(vec![1]),


### PR DESCRIPTION
to include ipv6 support we need to be able to identify which socket address was used to contact a node (the ipv4 or ipv6 one). Before this was trivial because we assumed "sanitized" inputs in the handler structures that should all have an ipv4 address. This is an intermediate step to enforce the handler has contactable node contacts with explicit socket addresses. I'm opting for now for the simpler solution, but in the future I think we can optimize this