### PR TITLE
Fix self-find query

### DIFF
--- a/src/query_pool/peers/closest.rs
+++ b/src/query_pool/peers/closest.rs
@@ -175,6 +175,10 @@ where
 
         // Incorporate the reported closer peers into the query.
         for peer in closer_peers {
+            // Skip if the peer is the target in order to avoid self-find query.
+            if &peer == self.target_key.preimage() {
+                continue;
+            }
             let key: Key<TNodeId> = peer.into();
             let distance = self.target_key.distance(&key);
             let peer = QueryPeer::new(key, QueryPeerState::NotContacted);


### PR DESCRIPTION
## Issue Addressed

Resolves #108


## Proposed Changes

Skip incorporate the discovered peer into `closest_peers` if the peer is the target in order to avoid self-find query.