### PR TITLE
Gracefully handle queries that contain the target

### DIFF
--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -243,7 +243,7 @@ fn find_seed_linear_topology() {
     }
 
     for (node, previous_node) in main_result.iter().skip(1).zip(main_result.clone()) {
-        let key: kbucket::Key<NodeId> = node.clone().into();
+        let key: kbucket::Key<NodeId> = (*node).into();
         let distance = key.log2_distance(&previous_node.into()).unwrap();
         let target_distance = key.log2_distance(&target.into()).unwrap();
         println!(
@@ -460,13 +460,12 @@ async fn test_findnode_query_with_target() {
     println!(
         "Query found {} peers. Total peers were: {}",
         found_nodes.len(),
-        nodes.iter().count() - 1
+        nodes.len() - 1
     );
 
     assert!(found_nodes
         .iter()
-        .find(|enr| enr.node_id() == target_node_id)
-        .is_some());
+        .any(|enr| enr.node_id() == target_node_id));
 }
 
 #[tokio::test]

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -15,6 +15,7 @@ fn update_enr(discv5: &mut Discv5, key: &str, value: &[u8]) -> bool {
     discv5.enr_insert(key, value).is_ok()
 }
 
+#[allow(dead_code)]
 async fn build_nodes(n: usize, base_port: u16) -> Vec<Discv5> {
     let mut nodes = Vec::new();
     let ip: Ipv4Addr = "127.0.0.1".parse().unwrap();
@@ -46,6 +47,7 @@ async fn build_nodes_from_keypairs(keys: Vec<CombinedKey>, base_port: u16) -> Ve
         let port = base_port + i as u16;
 
         let config = Discv5ConfigBuilder::new().build();
+
         let enr = EnrBuilder::new("v4")
             .ip4(ip)
             .udp4(port)
@@ -151,6 +153,99 @@ fn find_seed_spread_bucket() {
     println!("Found Seed: {}", seed);
     for (k, v) in buckets.iter() {
         println!("{}, {}", k, v);
+    }
+}
+
+/// Find a seed that gives nodes in a linear topology for query searching.
+///
+/// The target and the next node are within the last few buckets.
+///
+/// So we can do:
+/// N1 -> N2 -> N3 -> ..... NX
+/// in a query when searching for target. This means target an N+1 are in N's last few buckets.
+#[allow(dead_code)]
+fn find_seed_linear_topology() {
+    let mut seed = 1;
+    let bucket_tolerance = 3; // Target and next node must be in the last `bucket_tolerance` buckets.
+    let mut main_result;
+    let ordering;
+    'main: loop {
+        seed += 1;
+        if seed % 1000 == 0 {
+            println!("Trying seed: {}", seed);
+        }
+
+        let keys = generate_deterministic_keypair(11, seed);
+
+        let orig_node_ids = keys
+            .into_iter()
+            .map(|k| NodeId::from(k.public()))
+            .collect::<Vec<_>>();
+
+
+        let mut node_ids = orig_node_ids.clone();
+
+        let target = node_ids.remove(0);
+
+        let mut result = Vec::new();
+
+        // Can we arrange the rest of the nodes in some linear way.
+        while !node_ids.is_empty() {
+            let id = node_ids.remove(0);
+            
+            let distance = get_distance(target, id).unwrap_or(0);
+            // The target must be in the first bucket_tolerance buckets.
+            if distance <= 256- bucket_tolerance {
+                continue 'main;
+            }
+
+            // If this is the first node, add it to the result list and continue
+            if result.is_empty() {
+                result.push(id);
+            } else if !node_ids.is_empty() {
+                // try and find a linear match
+                match node_ids.iter().position(|id| get_distance(target,*id).unwrap_or(0) >= 256-bucket_tolerance) {
+                    Some(pos) => {
+                        let matching_id = node_ids.remove(pos);
+                        if get_distance(target,matching_id).unwrap_or(0) < 256 - bucket_tolerance {
+                            continue 'main; // all nodes need to be in this distance
+                        }
+                        result.push(id);
+                        result.push(matching_id);
+                    }
+                    None => {
+                        continue 'main;
+                    }
+                }
+            } else { 
+                result.push(id);
+            }
+        }
+        main_result = result;
+        // Target sits at the start
+        main_result.insert(0,target);
+        ordering = main_result.iter().map(|id| orig_node_ids.iter().position(|x| x == id).unwrap()).collect::<Vec<_>>();
+        break;
+    }
+    // We've found a solution. Check it.
+    println!("Found Seed: {}", seed);
+    println!("Ordering: {:?}", ordering);
+    let target = main_result.remove(0);
+    // remove the target
+    println!("Target: {}", target);
+    for (x,id) in main_result.iter().enumerate() {
+        println!("Node{}: {}", x, id);
+    }
+
+    for (node, previous_node) in main_result.iter().skip(1).zip(main_result.clone()) {
+        let key: kbucket::Key<NodeId> = node.clone().into();
+        let distance = key
+            .log2_distance(&previous_node.into())
+            .unwrap();
+        let target_distance = key
+            .log2_distance(&target.into())
+            .unwrap();
+        println!("Distance of node {} relative to next node: {} is: {},  relative to target {}", previous_node, node, distance, target_distance);
     }
 }
 
@@ -279,7 +374,11 @@ async fn test_findnode_query() {
     init();
     // build a collection of 8 nodes
     let total_nodes = 8;
-    let mut nodes = build_nodes(total_nodes, 30000).await;
+    // Seed is chosen for a linear topology. Each node is connected to each other and in the top 3
+    // buckets from each other and the target.
+    let mut keypairs = generate_deterministic_keypair(total_nodes + 1, 5);
+    let target_node_id = NodeId::from(keypairs.remove(0).public());
+    let mut nodes = build_nodes_from_keypairs(keypairs, 30000).await;
     let node_enrs: Vec<Enr<CombinedKey>> = nodes.iter().map(|n| n.local_enr()).collect();
 
     // link the nodes together
@@ -292,14 +391,12 @@ async fn test_findnode_query() {
         node.add_enr(previous_node_enr).unwrap();
     }
 
-    // pick a random node target
-    let target_random_node_id = NodeId::random();
 
     // start a query on the last node
     let found_nodes = nodes
         .last_mut()
         .unwrap()
-        .find_node(target_random_node_id)
+        .find_node(target_node_id)
         .await
         .unwrap();
 
@@ -318,7 +415,7 @@ async fn test_findnode_query() {
         found_nodes.len(),
         expected_node_ids.len()
     );
-    assert!(found_nodes.len() <= expected_node_ids.len());
+    assert_eq!(found_nodes.len(),expected_node_ids.len());
 }
 
 /// Run a query where the target is one of the nodes. We expect to result to return the target.
@@ -327,7 +424,11 @@ async fn test_findnode_query_with_target() {
     init();
     // build a collection of 8 nodes
     let total_nodes = 8;
-    let mut nodes = build_nodes(total_nodes, 40100).await;
+    // Seed is chosen for a linear topology. Each node is connected to each other and in the top 3
+    // buckets from each other and the target.
+    let keypairs = generate_deterministic_keypair(total_nodes + 1, 5);
+    let target_node_id = NodeId::from(keypairs[0].public());
+    let mut nodes = build_nodes_from_keypairs(keypairs, 40150).await;
     let node_enrs: Vec<Enr<CombinedKey>> = nodes.iter().map(|n| n.local_enr()).collect();
 
     // link the nodes together
@@ -344,9 +445,6 @@ async fn test_findnode_query_with_target() {
         );
         node.add_enr(previous_node_enr).unwrap();
     }
-
-    // let the first node be the target
-    let target_node_id = node_enrs[0].node_id();
 
     // start a query on the last node
     let found_nodes = nodes
@@ -365,7 +463,7 @@ async fn test_findnode_query_with_target() {
     assert!(found_nodes
         .iter()
         .find(|enr| enr.node_id() == target_node_id)
-        .is_some())
+        .is_some());
 }
 
 #[tokio::test]
@@ -376,7 +474,7 @@ async fn test_predicate_search() {
     let seed = 1652;
     // Generate `num_nodes` + bootstrap_node and target_node keypairs from given seed
     let keypairs = generate_deterministic_keypair(total_nodes + 2, seed);
-    let mut nodes = build_nodes_from_keypairs(keypairs, 12000).await;
+    let mut nodes = build_nodes_from_keypairs(keypairs, 1500).await;
     // Last node is bootstrap node in a star topology
     let bootstrap_node = nodes.remove(0);
     // target_node is not polled.

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -327,7 +327,7 @@ async fn test_findnode_query_with_target() {
     init();
     // build a collection of 8 nodes
     let total_nodes = 8;
-    let mut nodes = build_nodes(total_nodes, 30100).await;
+    let mut nodes = build_nodes(total_nodes, 40100).await;
     let node_enrs: Vec<Enr<CombinedKey>> = nodes.iter().map(|n| n.local_enr()).collect();
 
     // link the nodes together
@@ -336,7 +336,12 @@ async fn test_findnode_query_with_target() {
         let distance = key
             .log2_distance(&previous_node_enr.node_id().into())
             .unwrap();
-        println!("Distance of node relative to next: {}", distance);
+        println!(
+            "Distance of node: {} relative to next node:{} is:{}",
+            previous_node_enr.node_id(),
+            node.local_enr().node_id(),
+            distance
+        );
         node.add_enr(previous_node_enr).unwrap();
     }
 

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -182,7 +182,6 @@ fn find_seed_linear_topology() {
             .map(|k| NodeId::from(k.public()))
             .collect::<Vec<_>>();
 
-
         let mut node_ids = orig_node_ids.clone();
 
         let target = node_ids.remove(0);
@@ -192,10 +191,10 @@ fn find_seed_linear_topology() {
         // Can we arrange the rest of the nodes in some linear way.
         while !node_ids.is_empty() {
             let id = node_ids.remove(0);
-            
+
             let distance = get_distance(target, id).unwrap_or(0);
             // The target must be in the first bucket_tolerance buckets.
-            if distance <= 256- bucket_tolerance {
+            if distance <= 256 - bucket_tolerance {
                 continue 'main;
             }
 
@@ -204,10 +203,13 @@ fn find_seed_linear_topology() {
                 result.push(id);
             } else if !node_ids.is_empty() {
                 // try and find a linear match
-                match node_ids.iter().position(|id| get_distance(target,*id).unwrap_or(0) >= 256-bucket_tolerance) {
+                match node_ids
+                    .iter()
+                    .position(|id| get_distance(target, *id).unwrap_or(0) >= 256 - bucket_tolerance)
+                {
                     Some(pos) => {
                         let matching_id = node_ids.remove(pos);
-                        if get_distance(target,matching_id).unwrap_or(0) < 256 - bucket_tolerance {
+                        if get_distance(target, matching_id).unwrap_or(0) < 256 - bucket_tolerance {
                             continue 'main; // all nodes need to be in this distance
                         }
                         result.push(id);
@@ -217,14 +219,17 @@ fn find_seed_linear_topology() {
                         continue 'main;
                     }
                 }
-            } else { 
+            } else {
                 result.push(id);
             }
         }
         main_result = result;
         // Target sits at the start
-        main_result.insert(0,target);
-        ordering = main_result.iter().map(|id| orig_node_ids.iter().position(|x| x == id).unwrap()).collect::<Vec<_>>();
+        main_result.insert(0, target);
+        ordering = main_result
+            .iter()
+            .map(|id| orig_node_ids.iter().position(|x| x == id).unwrap())
+            .collect::<Vec<_>>();
         break;
     }
     // We've found a solution. Check it.
@@ -233,19 +238,18 @@ fn find_seed_linear_topology() {
     let target = main_result.remove(0);
     // remove the target
     println!("Target: {}", target);
-    for (x,id) in main_result.iter().enumerate() {
+    for (x, id) in main_result.iter().enumerate() {
         println!("Node{}: {}", x, id);
     }
 
     for (node, previous_node) in main_result.iter().skip(1).zip(main_result.clone()) {
         let key: kbucket::Key<NodeId> = node.clone().into();
-        let distance = key
-            .log2_distance(&previous_node.into())
-            .unwrap();
-        let target_distance = key
-            .log2_distance(&target.into())
-            .unwrap();
-        println!("Distance of node {} relative to next node: {} is: {},  relative to target {}", previous_node, node, distance, target_distance);
+        let distance = key.log2_distance(&previous_node.into()).unwrap();
+        let target_distance = key.log2_distance(&target.into()).unwrap();
+        println!(
+            "Distance of node {} relative to next node: {} is: {},  relative to target {}",
+            previous_node, node, distance, target_distance
+        );
     }
 }
 
@@ -391,7 +395,6 @@ async fn test_findnode_query() {
         node.add_enr(previous_node_enr).unwrap();
     }
 
-
     // start a query on the last node
     let found_nodes = nodes
         .last_mut()
@@ -415,7 +418,7 @@ async fn test_findnode_query() {
         found_nodes.len(),
         expected_node_ids.len()
     );
-    assert_eq!(found_nodes.len(),expected_node_ids.len());
+    assert_eq!(found_nodes.len(), expected_node_ids.len());
 }
 
 /// Run a query where the target is one of the nodes. We expect to result to return the target.

--- a/src/service.rs
+++ b/src/service.rs
@@ -693,7 +693,9 @@ impl Service {
                             );
                             let ban_timeout = self.config.ban_duration.map(|v| Instant::now() + v);
                             PERMIT_BAN_LIST.write().ban(node_address, ban_timeout);
-                            nodes.retain(|enr| peer_key.log2_distance(&enr.node_id().into()).is_none());
+                            nodes.retain(|enr| {
+                                peer_key.log2_distance(&enr.node_id().into()).is_none()
+                            });
                         }
                     } else {
                         let before_len = nodes.len();

--- a/src/service.rs
+++ b/src/service.rs
@@ -691,10 +691,10 @@ impl Service {
                                 "Peer returned more than one ENR for itself. Blacklisting {}",
                                 node_address
                             );
+                            let ban_timeout = self.config.ban_duration.map(|v| Instant::now() + v);
+                            PERMIT_BAN_LIST.write().ban(node_address, ban_timeout);
+                            nodes.retain(|enr| peer_key.log2_distance(&enr.node_id().into()).is_none());
                         }
-                        let ban_timeout = self.config.ban_duration.map(|v| Instant::now() + v);
-                        PERMIT_BAN_LIST.write().ban(node_address, ban_timeout);
-                        nodes.retain(|enr| peer_key.log2_distance(&enr.node_id().into()).is_none());
                     } else {
                         let before_len = nodes.len();
                         nodes.retain(|enr| {

--- a/src/service.rs
+++ b/src/service.rs
@@ -45,6 +45,10 @@ mod ip_vote;
 mod query_info;
 mod test;
 
+/// The number of distances (buckets) we simultaneously request from each peer.
+/// NOTE: This must not be larger than 127.
+pub(crate) const DISTANCES_TO_REQUEST_PER_PEER: usize = 3;
+
 /// Request type for Protocols using `TalkReq` message.
 ///
 /// Automatically responds with an empty body on drop if
@@ -117,9 +121,6 @@ impl TalkRequest {
         Ok(())
     }
 }
-
-/// The number of distances (buckets) we simultaneously request from each peer.
-pub(crate) const DISTANCES_TO_REQUEST_PER_PEER: usize = 3;
 
 /// The types of requests to send to the Discv5 service.
 pub enum ServiceRequest {
@@ -1149,15 +1150,21 @@ impl Service {
                             source, reason
                         );
 
-                        false // Remove this peer from the discovered list
-                    } else {
-                        true // Keep this peer in the list
+                        return false; // Remove this peer from the discovered list if the update failed
                     }
-                } else {
-                    true // We don't need to update ENR
                 }
             } else {
-                false // Didn't pass the table filter
+                return false; // Didn't pass the table filter remove the peer
+            }
+
+            // The remaining ENRs are used if this request was part of a query. If we are
+            // requesting the target of the query, this ENR could be the result of requesting the
+            // target-nodes own id. We don't want to add this as a "new" discovered peer in the
+            // query, so we remove it from the discovered list here.
+            if source == &enr.node_id() {
+                false // remove from the list
+            } else {
+                true
             }
         });
 
@@ -1423,17 +1430,7 @@ impl Service {
             QueryPoolState::Finished(query) => Poll::Ready(QueryEvent::Finished(Box::new(query))),
             QueryPoolState::Waiting(Some((query, return_peer))) => {
                 let node_id = return_peer;
-
-                let request_body = match query.target().rpc_request(return_peer) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        // dst node is local_key, report failure
-                        error!("Send RPC failed: {}", e);
-                        query.on_failure(&node_id);
-                        return Poll::Pending;
-                    }
-                };
-
+                let request_body = query.target().rpc_request(return_peer);
                 Poll::Ready(QueryEvent::Waiting(query.id(), node_id, request_body))
             }
             QueryPoolState::Timeout(query) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1161,11 +1161,7 @@ impl Service {
             // requesting the target of the query, this ENR could be the result of requesting the
             // target-nodes own id. We don't want to add this as a "new" discovered peer in the
             // query, so we remove it from the discovered list here.
-            if source == &enr.node_id() {
-                false // remove from the list
-            } else {
-                true
-            }
+            source != &enr.node_id()
         });
 
         // if this is part of a query, update the query

--- a/src/service/query_info.rs
+++ b/src/service/query_info.rs
@@ -17,6 +17,7 @@ pub struct QueryInfo {
     pub callback: oneshot::Sender<Vec<Enr>>,
 
     /// The number of distances we request for each peer.
+    /// NOTE: This must not be larger than 127.
     pub distances_to_request: usize,
 }
 
@@ -29,16 +30,14 @@ pub enum QueryType {
 
 impl QueryInfo {
     /// Builds an RPC Request, given the QueryInfo
-    pub(crate) fn rpc_request(&self, peer: NodeId) -> Result<RequestBody, &'static str> {
-        let request = match self.query_type {
+    pub(crate) fn rpc_request(&self, peer: NodeId) -> RequestBody {
+        match self.query_type {
             QueryType::FindNode(node_id) => {
                 let distances = findnode_log2distance(node_id, peer, self.distances_to_request)
-                    .ok_or("Requested a node find itself")?;
+                    .unwrap_or(vec![0]);
                 RequestBody::FindNode { distances }
             }
-        };
-
-        Ok(request)
+        }
     }
 }
 

--- a/src/service/query_info.rs
+++ b/src/service/query_info.rs
@@ -34,7 +34,7 @@ impl QueryInfo {
         match self.query_type {
             QueryType::FindNode(node_id) => {
                 let distances = findnode_log2distance(node_id, peer, self.distances_to_request)
-                    .unwrap_or(vec![0]);
+                    .unwrap_or_else(|| vec![0]);
                 RequestBody::FindNode { distances }
             }
         }


### PR DESCRIPTION
Queries that contain a target attempt to contact the target to search for itself.

Previously this resulted in an RPC error as highlighted in #108. 

This PR permits these RPC requests and adds the target in the found closest peers, if that peer is contactable.