### PR TITLE
Handle overflow in `session.counter` explicitly

### DIFF
--- a/src/handler/session.rs
+++ b/src/handler/session.rs
@@ -57,7 +57,7 @@ impl Session {
         src_id: NodeId,
         message: &[u8],
     ) -> Result<Packet, Discv5Error> {
-        self.counter += 1;
+        self.counter = self.counter.wrapping_add(1);
 
         // If the message nonce length is ever set below 4 bytes this will explode. The packet
         // size constants shouldn't be modified.

--- a/src/handler/session.rs
+++ b/src/handler/session.rs
@@ -254,9 +254,14 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-    use crate::handler::session::{Keys, Session};
-    use crate::handler::{crypto, NodeContact};
-    use crate::packet::ChallengeData;
+    use crate::{
+        handler::{
+            crypto,
+            session::{Keys, Session},
+            NodeContact,
+        },
+        packet::ChallengeData,
+    };
     use enr::{CombinedKey, EnrBuilder, NodeId};
     use std::convert::TryFrom;
 


### PR DESCRIPTION
https://github.com/sigp/discv5/blob/63f00ae56a912e4fc3aef8f0d910c9fee9a65f12/src/handler/session.rs#L60

This doesn't panic in release mode, but it would be better to use explicit `wrapping_*` operations. 