### PR TITLE
Correct Handshake race condition

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -24,7 +24,7 @@
 //!
 //! Requests from the application layer can be made via the receive channel using a [`HandlerIn`].
 //! Responses from the application layer can be made via the receive channel using a [`HandlerIn`].
-//! Messages from the a node on the network come by [`Socket`] and get the form of a [`HandlerOut`]
+//! Messages from a node on the network come by [`Socket`] and get the form of a [`HandlerOut`]
 //! and can be forwarded to the application layer via the send channel.
 use crate::{
     config::Discv5Config,
@@ -540,14 +540,11 @@ impl Handler {
             return;
         }
 
-        // Ignore this request if the session is already established
-        if self.sessions.get(&node_address).is_some() {
-            trace!(
-                "Session already established. WHOAREYOU not sent to {}",
-                node_address
-            );
-            return;
-        }
+        // NOTE: We do not check if we have an active session here. This was checked before
+        // requesting the ENR from the service. It could be the case we have established a session
+        // in the meantime, we allow this challenge to establish a second session in the event this
+        // race occurs. The nodes will decide amongst themselves which session keys to use (the
+        // most recent).
 
         // It could be the case we have sent an ENR with an active request, however we consider
         // these independent as this is in response to an unknown packet. If the ENR it not in our

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -467,7 +467,7 @@ impl Handler {
 
         // If there is already an active request or an active challenge (WHOAREYOU sent) for this node, add to pending requests
         if self.active_requests.get(&node_address).is_some()
-            | self.active_challenges.get(&node_address).is_some()
+            || self.active_challenges.get(&node_address).is_some()
         {
             trace!("Request queued for node: {}", node_address);
             self.pending_requests

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -782,12 +782,15 @@ impl Handler {
                         }
                         self.new_session(node_address.clone(), session);
                         self.handle_message(
-                            node_address,
+                            node_address.clone(),
                             message_nonce,
                             message,
                             authenticated_data,
                         )
                         .await;
+                        // We could have pending messages that were awaiting this session to be
+                        // established. If so process them.
+                        self.send_next_request(node_address).await;
                     } else {
                         // IP's or NodeAddress don't match. Drop the session.
                         warn!(

--- a/src/handler/session.rs
+++ b/src/handler/session.rs
@@ -19,9 +19,12 @@ pub(crate) struct Keys {
 pub(crate) struct Session {
     /// The current keys used to encrypt/decrypt messages.
     keys: Keys,
-    /// If a new handshake is being established, these keys can be tried to determine if this new
-    /// set of keys is canon.
-    awaiting_keys: Option<Keys>,
+    /// If a new handshake is being established, the older keys are maintained as race
+    /// conditions in the handshake can give different views of which keys are canon.
+    /// The key that worked to decrypt our last message (or are freshly established) exist in
+    /// `keys` and previous keys are optionally stored in `old_keys`. We attempt to decrypt
+    /// messages with `keys` before optionally trying `old_keys`.
+    old_keys: Option<Keys>,
     /// If we contacted this node without an ENR, i.e. via a multiaddr, during the session
     /// establishment we request the nodes ENR. Once the ENR is received and verified, this session
     /// becomes established.
@@ -37,7 +40,7 @@ impl Session {
     pub fn new(keys: Keys) -> Self {
         Session {
             keys,
-            awaiting_keys: None,
+            old_keys: None,
             awaiting_enr: None,
             counter: 0,
         }
@@ -45,8 +48,8 @@ impl Session {
 
     /// A new session has been established. Update this session based on the new session.
     pub fn update(&mut self, new_session: Session) {
-        // Await the new sessions keys
-        self.awaiting_keys = Some(new_session.keys);
+        // Optimistically assume the new keys are canonical.
+        self.old_keys = Some(std::mem::replace(&mut self.keys, new_session.keys));
         self.awaiting_enr = new_session.awaiting_enr;
     }
 
@@ -100,17 +103,26 @@ impl Session {
         message: &[u8],
         aad: &[u8],
     ) -> Result<Vec<u8>, Discv5Error> {
-        // try with the new keys
-        if let Some(new_keys) = self.awaiting_keys.take() {
-            let result =
-                crypto::decrypt_message(&new_keys.decryption_key, message_nonce, message, aad);
-            if result.is_ok() {
-                self.keys = new_keys;
-                return result;
-            }
+        // First try with the canonical keys.
+        let result_canon =
+            crypto::decrypt_message(&self.keys.decryption_key, message_nonce, message, aad);
+
+        // If decryption is fine, nothing more to do.
+        if result_canon.is_ok() {
+            return result_canon;
         }
-        // if it failed try with the old keys
-        crypto::decrypt_message(&self.keys.decryption_key, message_nonce, message, aad)
+
+        // If these keys did not work, try old_keys
+        if let Some(old_keys) = self.old_keys.take() {
+            let result =
+                crypto::decrypt_message(&old_keys.decryption_key, message_nonce, message, aad);
+            if result.is_ok() {
+                // rotate the keys
+                self.old_keys = Some(std::mem::replace(&mut self.keys, old_keys));
+            }
+            return result;
+        }
+        result_canon
     }
 
     /* Session Helper Functions */

--- a/src/lru_time_cache.rs
+++ b/src/lru_time_cache.rs
@@ -60,6 +60,7 @@ impl<K: Clone + Eq + Hash, V> LruTimeCache<K, V> {
 
     /// Returns a reference to the value with the given `key`, if present and not expired, without
     /// updating the timestamp.
+    #[allow(dead_code)]
     pub fn peek(&self, key: &K) -> Option<&V> {
         if let Some((value, time)) = self.map.get(key) {
             return if *time + self.ttl >= Instant::now() {

--- a/src/lru_time_cache.rs
+++ b/src/lru_time_cache.rs
@@ -38,6 +38,7 @@ impl<K: Clone + Eq + Hash, V> LruTimeCache<K, V> {
 
     /// Retrieves a reference to the value stored under `key`, or `None` if the key doesn't exist.
     /// Also removes expired elements and updates the time.
+    #[allow(dead_code)]
     pub fn get(&mut self, key: &K) -> Option<&V> {
         self.get_mut(key).map(|value| &*value)
     }


### PR DESCRIPTION
Attempt to handle issues raised by @ackintosh here: https://github.com/ackintosh/test-plan-discv5/pull/13#issuecomment-1120430861

From what I can tell it seems we attempt new handshakes even when one is underway. 

To address this, I think we can prevent sending messages if we are awaiting a challenge response. We wait for either the response, or a timeout before sending the message and optionally establishing a new session. 

This way, it should work the first go, and we don't have to increment the number of retries.

@ackintosh - Could you check to see if this PR resolves your issue. (Sorry for the delay, have a few things going on).