### PR TITLE
Add Discv5Event::SessionEstablished to surface ENRs

### DIFF
--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -193,6 +193,7 @@ async fn main() {
                     Discv5Event::Discovered(enr) => info!("Enr discovered {}", enr),
                     Discv5Event::EnrAdded { enr, replaced: _ } => info!("Enr added {}", enr),
                     Discv5Event::NodeInserted { node_id, replaced: _ } => info!("Node inserted {}", node_id),
+                    Discv5Event::SessionEstablished(enr) => info!("Session established {}", enr),
                     Discv5Event::SocketUpdated(addr) => info!("Socket updated {}", addr),
                     Discv5Event::TalkRequest(_) => info!("Talk request received"),
                 };

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -193,7 +193,7 @@ async fn main() {
                     Discv5Event::Discovered(enr) => info!("Enr discovered {}", enr),
                     Discv5Event::EnrAdded { enr, replaced: _ } => info!("Enr added {}", enr),
                     Discv5Event::NodeInserted { node_id, replaced: _ } => info!("Node inserted {}", node_id),
-                    Discv5Event::SessionEstablished(enr) => info!("Session established {}", enr),
+                    Discv5Event::SessionEstablished(enr, _) => info!("Session established {}", enr),
                     Discv5Event::SocketUpdated(addr) => info!("Socket updated {}", addr),
                     Discv5Event::TalkRequest(_) => info!("Talk request received"),
                 };

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -62,7 +62,7 @@ pub enum Discv5Event {
         replaced: Option<NodeId>,
     },
     /// A new session has been established with a node.
-    SessionEstablished(NodeContact),
+    SessionEstablished(Enr, SocketAddr),
     /// Our local ENR IP address has been updated.
     SocketUpdated(SocketAddr),
     /// A node has initiated a talk request.

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -61,6 +61,8 @@ pub enum Discv5Event {
         node_id: NodeId,
         replaced: Option<NodeId>,
     },
+    /// A new session has been established with a node.
+    SessionEstablished(Enr),
     /// Our local ENR IP address has been updated.
     SocketUpdated(SocketAddr),
     /// A node has initiated a talk request.

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -62,7 +62,7 @@ pub enum Discv5Event {
         replaced: Option<NodeId>,
     },
     /// A new session has been established with a node.
-    SessionEstablished(Enr),
+    SessionEstablished(NodeContact),
     /// Our local ENR IP address has been updated.
     SocketUpdated(SocketAddr),
     /// A node has initiated a talk request.

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -169,7 +169,7 @@ async fn multiple_messages() {
     let sender = async move {
         loop {
             match sender_handler_recv.recv().await {
-                Some(HandlerOut::Established(_, _)) => {
+                Some(HandlerOut::Established(_, _, _)) => {
                     // now the session is established, send the rest of the messages
                     for _ in 0..messages_to_send - 1 {
                         let _ = sender_handler.send(HandlerIn::Request(

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -66,17 +66,6 @@ impl NodeContact {
         )
     }
 
-    pub fn from_non_contactable_and_socket_addr(
-        non_contactable: NonContactable,
-        socket_addr: SocketAddr,
-    ) -> Self {
-        NodeContact {
-            public_key: non_contactable.enr.public_key(),
-            socket_addr,
-            enr: Some(non_contactable.enr),
-        }
-    }
-
     pub fn try_from_enr(enr: Enr, ip_mode: IpMode) -> Result<Self, NonContactable> {
         let socket_addr = match ip_mode.get_contactable_addr(&enr) {
             Some(socket_addr) => socket_addr,

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -66,6 +66,17 @@ impl NodeContact {
         )
     }
 
+    pub fn from_non_contactable_and_socket_addr(
+        non_contactable: NonContactable,
+        socket_addr: SocketAddr,
+    ) -> Self {
+        NodeContact {
+            public_key: non_contactable.enr.public_key(),
+            socket_addr,
+            enr: Some(non_contactable.enr),
+        }
+    }
+
     pub fn try_from_enr(enr: Enr, ip_mode: IpMode) -> Result<Self, NonContactable> {
         let socket_addr = match ip_mode.get_contactable_addr(&enr) {
             Some(socket_addr) => socket_addr,

--- a/src/service.rs
+++ b/src/service.rs
@@ -342,11 +342,7 @@ impl Service {
                 Some(event) = self.handler_recv.recv() => {
                     match event {
                         HandlerOut::Established(enr, socket_addr, direction) => {
-                            let node_contact = match NodeContact::try_from_enr(enr.clone(), self.config.ip_mode) {
-                               Ok(contact) => contact,
-                               Err(non_contactable) => NodeContact::from_non_contactable_and_socket_addr(non_contactable, socket_addr),
-                            };
-                            self.send_event(Discv5Event::SessionEstablished(node_contact));
+                            self.send_event(Discv5Event::SessionEstablished(enr.clone(), socket_addr));
                             self.inject_session_established(enr, direction);
                         }
                         HandlerOut::Request(node_address, request) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -341,8 +341,12 @@ impl Service {
                 }
                 Some(event) = self.handler_recv.recv() => {
                     match event {
-                        HandlerOut::Established(enr, direction) => {
-                            self.send_event(Discv5Event::SessionEstablished(enr.clone()));
+                        HandlerOut::Established(enr, socket_addr, direction) => {
+                            let node_contact = match NodeContact::try_from_enr(enr.clone(), self.config.ip_mode) {
+                               Ok(contact) => contact,
+                               Err(non_contactable) => NodeContact::from_non_contactable_and_socket_addr(non_contactable, socket_addr),
+                            };
+                            self.send_event(Discv5Event::SessionEstablished(node_contact));
                             self.inject_session_established(enr, direction);
                         }
                         HandlerOut::Request(node_address, request) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -342,7 +342,8 @@ impl Service {
                 Some(event) = self.handler_recv.recv() => {
                     match event {
                         HandlerOut::Established(enr, direction) => {
-                            self.inject_session_established(enr,direction);
+                            self.send_event(Discv5Event::SessionEstablished(enr.clone()));
+                            self.inject_session_established(enr, direction);
                         }
                         HandlerOut::Request(node_address, request) => {
                                 self.handle_rpc_request(node_address, *request);


### PR DESCRIPTION
Closes #96.

Add a new `Discv5Event` variant to surface ENRs from established sessions (completed handshakes). This change essentially propagates the `HandlerOut::Established` event upward so that the application layer can receive the event. The propagated ENR does not go through the "contactable" check performed in `inject_session_established`. Therefore, the application has no guarantee that the ENR from this event is contactable.

The discussion in the associated issue suggested this path to resolution. If `SessionEstablished` does not represent desired semantics, then please suggest a more appropriate name.