### PR TITLE
ENRs for Discv5

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,54 @@ A simple example of creating this service is as follows:
       println!("Found nodes: {:?}", found_nodes);
    });
 ```
+
+# Addresses in ENRs 
+
+This protocol will drop messages (i.e not respond to requests) from peers that
+advertise non-contactable address in their ENR (e.g `127.0.0.1`). This section
+explains the rationale behind this design decision.
+
+An ENR is a signed record which is primarily used in this protocol for
+identifying and connecting to peers. ENRs have **OPTIONAL** `ip` and `port`
+fields.
+
+If a node does not know its contactable address (i.e if it is behind a NAT), it should leave these fields
+empty. This is done for the following reasons:
+1. When we receive an ENR we must decide whether to add it to our local routing
+   table and advertise it to other peers. If a node has put some
+   non-contactable address in the ENR (i.e `127.0.0.1`) we cannot use this ENR
+   to contact the node and we therefore do not wish to advertise it to other
+   nodes. Putting a non-contactable address is therefore functionally
+   equivalent to leaving the fields empty.
+2. For every new inbound connection, we do not wish to check that the address
+   given to us in an `ENR` is contactable. We do not want the scenario, where
+   any peer can give us any address and force us to attempt a connection to
+   arbitrary addresses (to check their validity) as it consumes unnecessary
+   bandwidth and we want to avoid DOS attacks where malicious users spam many
+   nodes attempting them all to send messages to a victim IP.
+
+## How this protocol handles advertised IPs in ENRs
+
+To handle the above two cases this protocol filters out and only advertises
+contactable ENRs. It doesn't make sense for a discovery protocol to advertise
+non-contactable peers.
+
+This is done in the following way:
+
+1. If a connecting node provides and ENR without specifying an address (this
+   should be the default case for most nodes behind a NAT, or ones that have
+   just started) we consider this valid. Typically this will occur when a node
+   has yet to determine its external IP address via PONG responses and has not
+   updated its ENR to a contactable address. In this case, we respond to all
+   requests this peer asks for but we do not store or add its ENR to our
+   routing table.
+2. If a peer connects to us with an ENR that specifies an IP address that
+   matches the src address we received the packet from, we consider this peer
+   valid and attempt to add it to our local routing table and therefore may advertise
+   its ENR to others.
+3. If a peer connects to us with an ENR that specifies an IP address that does
+   not match the src socket it connects to us on (i.e `127.0.0.1`, or
+   potentially some internal subnet IP) we consider this peer malicious/faulty
+   and drop all packets. This way we can efficiently drop peers that may try to
+   get us to send messages to arbitrary remote IPs, and we can be sure that all
+   ENRs in our routing table are contactable (at least by our local node).

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ A simple example of creating this service is as follows:
 # Addresses in ENRs 
 
 This protocol will drop messages (i.e not respond to requests) from peers that
-advertise non-contactable address in their ENR (e.g `127.0.0.1`). This section
+advertise non-contactable address in their ENR (e.g `127.0.0.1` when connecting
+to non-local nodes). This section
 explains the rationale behind this design decision.
 
 An ENR is a signed record which is primarily used in this protocol for
@@ -88,7 +89,8 @@ If a node does not know its contactable address (i.e if it is behind a NAT), it 
 empty. This is done for the following reasons:
 1. When we receive an ENR we must decide whether to add it to our local routing
    table and advertise it to other peers. If a node has put some
-   non-contactable address in the ENR (i.e `127.0.0.1`) we cannot use this ENR
+   non-contactable address in the ENR (e.g `127.0.0.1` when connecting to
+   non-local nodes) we cannot use this ENR
    to contact the node and we therefore do not wish to advertise it to other
    nodes. Putting a non-contactable address is therefore functionally
    equivalent to leaving the fields empty.
@@ -119,8 +121,10 @@ This is done in the following way:
    valid and attempt to add it to our local routing table and therefore may advertise
    its ENR to others.
 3. If a peer connects to us with an ENR that specifies an IP address that does
-   not match the src socket it connects to us on (i.e `127.0.0.1`, or
-   potentially some internal subnet IP) we consider this peer malicious/faulty
+   not match the src socket it connects to us on (e.g `127.0.0.1`, or
+   potentially some internal subnet IP that is unreachable from our current
+   network) we consider this peer malicious/faulty
    and drop all packets. This way we can efficiently drop peers that may try to
    get us to send messages to arbitrary remote IPs, and we can be sure that all
-   ENRs in our routing table are contactable (at least by our local node).
+   ENRs in our routing table are contactable (at least by our local node at
+   some point in time).


### PR DESCRIPTION
This adds a brief outline for our design decision to drop requests from implementations that advertise non-contactable addresses in their ENR.

This issue continually comes up, so I think its necessary we add it to our README.