### PR TITLE
Fix a double-lock bug in update_local_enr_socket

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -350,7 +350,7 @@ impl Discv5 {
 
     /// Updates the local ENR TCP/UDP socket.
     pub fn update_local_enr_socket(&self, socket_addr: SocketAddr, is_tcp: bool) -> bool {
-        let local_enr = self.local_enr.read();
+        let mut local_enr = self.local_enr.write();
         let update_socket: Option<SocketAddr> = match socket_addr {
             SocketAddr::V4(socket_addr) => {
                 if Some(socket_addr) != local_enr.udp4_socket() {
@@ -369,13 +369,11 @@ impl Discv5 {
         };
         if let Some(new_socket_addr) = update_socket {
             if is_tcp {
-                self.local_enr
-                    .write()
+                local_enr
                     .set_tcp_socket(new_socket_addr, &self.enr_key.read())
                     .is_ok()
             } else {
-                self.local_enr
-                    .write()
+                local_enr
                     .set_udp_socket(new_socket_addr, &self.enr_key.read())
                     .is_ok()
             }


### PR DESCRIPTION
There are two double-lock bugs in `update_local_enr_socket`.
`local_enr` is RwLock.
The first read lock:
https://github.com/sigp/discv5/blob/878ef13378017bd8e5bf6426f23c3bf02f9e427d/src/discv5.rs#L353
The second write locks:
1. https://github.com/sigp/discv5/blob/878ef13378017bd8e5bf6426f23c3bf02f9e427d/src/discv5.rs#L371-L373
2. https://github.com/sigp/discv5/blob/878ef13378017bd8e5bf6426f23c3bf02f9e427d/src/discv5.rs#L376-L378

The fix is to replace the first read lock with one write lock,
and reuse the write lock.
