### PR TITLE
Remove FINDNODE request bucket limit

### DIFF
--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -590,7 +590,7 @@ where
                 self.applied_pending.push_back(applied);
                 // Break if we've reached the maximum number of nodes we will provide in the
                 // response. There's no need to apply pending buckets past this point, the nodes
-                // won't be part of the response.
+                // in those buckets won't be part of the response.
                 node_count += bucket.num_entries();
                 if node_count >= max_nodes {
                     break

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -593,7 +593,7 @@ where
                 // in those buckets won't be part of the response.
                 node_count += bucket.num_entries();
                 if node_count >= max_nodes {
-                    break
+                    break;
                 }
             }
         }

--- a/src/kbucket.rs
+++ b/src/kbucket.rs
@@ -581,12 +581,20 @@ where
             .collect::<Vec<_>>();
 
         // Apply pending nodes
+        let mut node_count = 0;
         for distance in &distances {
             // The log2 distance ranges from 1-256 and is always 1 more than the bucket index. For this
             // reason we subtract 1 from log2 distance to get the correct bucket index.
             let bucket = &mut self.buckets[(distance - 1) as usize];
             if let Some(applied) = bucket.apply_pending() {
-                self.applied_pending.push_back(applied)
+                self.applied_pending.push_back(applied);
+                // Break if we've reached the maximum number of nodes we will provide in the
+                // response. There's no need to apply pending buckets past this point, the nodes
+                // won't be part of the response.
+                node_count += bucket.num_entries();
+                if node_count >= max_nodes {
+                    break
+                }
             }
         }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -469,13 +469,6 @@ impl Message {
                 }
                 let distances = rlp.list_at::<u64>(1)?;
 
-                if distances.len() > 10 {
-                    warn!(
-                        "Rejected FindNode request asking for too many buckets {}, maximum 10",
-                        distances.len()
-                    );
-                    return Err(DecoderError::Custom("FINDNODE request too large"));
-                }
                 for distance in distances.iter() {
                     if distance > &256u64 {
                         warn!(

--- a/src/service.rs
+++ b/src/service.rs
@@ -975,9 +975,6 @@ impl Service {
         rpc_id: RequestId,
         mut distances: Vec<u64>,
     ) {
-        // NOTE: At most we only allow 5 distances to be sent (see the decoder). If each of these
-        // buckets are full, that equates to 80 ENR's to respond with.
-
         let mut nodes_to_send = Vec::new();
         distances.sort_unstable();
         distances.dedup();


### PR DESCRIPTION
I don't see the purpose of this limit. If anything, I think it might hurt communications with other discovery implementations. It will ignore requests with more than 10 distances. The spec doesn't seem to have any limits on the number of distances in the request message, just the recommendation that the result is limited to 16 nodes, which is already done:

https://github.com/sigp/discv5/blob/878ef13378017bd8e5bf6426f23c3bf02f9e427d/src/service.rs#L996-L999

The `nodes_by_distance` function will stop adding to the results when the limit (`self.config.max_nodes_response`) is reached. By default, this configuration value is 16, [like the spec recommends](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#findnode-request-0x03). And the maximum packet size of 1280 should enforce some type of limit on the number of distances. Is there a reason for the limit of 10 distances?