### PR TITLE
Update max responses check for nodes response

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -54,7 +54,8 @@ pub(crate) const DISTANCES_TO_REQUEST_PER_PEER: usize = 3;
 /// can be returned. Datagrams have a max size of 1280 and ENR's have a max size
 /// of 300 bytes. Bucket sizes should be 16. Therefore, to return all required peers
 /// there should be no more than `5 * DISTANCES_TO_REQUEST_PER_PEER` responses.
-pub(crate) const MAX_NODES_RESPONSES: usize = (MAX_NODES_PER_BUCKET / 4 + 1 ) * DISTANCES_TO_REQUEST_PER_PEER;
+pub(crate) const MAX_NODES_RESPONSES: usize =
+    (MAX_NODES_PER_BUCKET / 4 + 1) * DISTANCES_TO_REQUEST_PER_PEER;
 
 /// Request type for Protocols using `TalkReq` message.
 ///
@@ -733,7 +734,7 @@ impl Service {
                         // another response
                         // If we have already received all our required nodes, drop any extra
                         // rpc messages.
-                        if  current_response.received_nodes.len() < self.config.max_nodes_response
+                        if current_response.received_nodes.len() < self.config.max_nodes_response
                             && (current_response.count as u64) < total
                             && current_response.count < MAX_NODES_RESPONSES
                         {

--- a/src/service.rs
+++ b/src/service.rs
@@ -52,8 +52,8 @@ pub(crate) const DISTANCES_TO_REQUEST_PER_PEER: usize = 3;
 
 /// Currently, a maximum of `DISTANCES_TO_REQUEST_PER_PEER * BUCKET_SIZE` peers
 /// can be returned. Datagrams have a max size of 1280 and ENR's have a max size
-/// of 300 bytes. Bucket sizes should be 16. Therefore, there should be no more
-/// than `5 * DISTANCES_TO_REQUEST_PER_PEER` responses, to return all required peers.
+/// of 300 bytes. Bucket sizes should be 16. Therefore, to return all required peers
+/// there should be no more than `5 * DISTANCES_TO_REQUEST_PER_PEER` responses.
 pub(crate) const MAX_RESPONSES: usize = 5 * DISTANCES_TO_REQUEST_PER_PEER;
 
 /// Request type for Protocols using `TalkReq` message.


### PR DESCRIPTION
When reviewing the nodes response handler, I noticed that the maximum number of responses check is a bit weird. It will print a warning if there are going to be more than 15 packets (`DISTANCES_TO_REQUEST_PER_PEER * 5`) but it will stop processing after 6 (`self.config.max_nodes_response / 3 + 1`) packets. Am I understanding this correctly?

This PR will:

* Make a new constant: `MAX_RESPONSES`
* Use this constant for both checks.