### PR TITLE
Move RequestCall into individual file

### DIFF
--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -21,7 +21,7 @@ impl ActiveRequests {
     }
 
     pub(crate) fn insert(&mut self, node_address: NodeAddress, request_call: RequestCall) {
-        let nonce = *request_call.packet.message_nonce();
+        let nonce = *request_call.packet().message_nonce();
         self.active_requests_mapping
             .insert(node_address.clone(), request_call);
         self.active_requests_nonce_mapping
@@ -55,7 +55,7 @@ impl ActiveRequests {
                 // Remove the associated nonce mapping.
                 match self
                     .active_requests_nonce_mapping
-                    .remove(request_call.packet.message_nonce())
+                    .remove(request_call.packet().message_nonce())
                 {
                     Some(_) => Some(request_call),
                     None => {
@@ -84,7 +84,7 @@ impl ActiveRequests {
         }
 
         for (address, request) in self.active_requests_mapping.iter() {
-            let nonce = request.packet.message_nonce();
+            let nonce = request.packet().message_nonce();
             if !self.active_requests_nonce_mapping.contains_key(nonce) {
                 panic!("Address {} maps to request with nonce {:?}, which does not exist in `active_requests_nonce_mapping`", address, nonce);
             }
@@ -99,7 +99,7 @@ impl Stream for ActiveRequests {
             Poll::Ready(Some(Ok((node_address, request_call)))) => {
                 // Remove the associated nonce mapping.
                 self.active_requests_nonce_mapping
-                    .remove(request_call.packet.message_nonce());
+                    .remove(request_call.packet().message_nonce());
                 Poll::Ready(Some(Ok((node_address, request_call))))
             }
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),

--- a/src/handler/request_call.rs
+++ b/src/handler/request_call.rs
@@ -1,0 +1,104 @@
+pub use crate::node_info::{NodeAddress, NodeContact};
+use crate::{
+    packet::Packet,
+    rpc::{Request, RequestId},
+};
+
+/// A request to a node that we are waiting for a response.
+#[derive(Debug)]
+pub(crate) struct RequestCall {
+    contact: NodeContact,
+    /// The raw discv5 packet sent.
+    packet: Packet,
+    /// The unencrypted message. Required if need to re-encrypt and re-send.
+    request: Request,
+    /// Handshakes attempted.
+    handshake_sent: bool,
+    /// The number of times this request has been re-sent.
+    retries: u8,
+    /// If we receive a Nodes Response with a total greater than 1. This keeps track of the
+    /// remaining responses expected.
+    remaining_responses: Option<u64>,
+    /// Signifies if we are initiating the session with a random packet. This is only used to
+    /// determine the connection direction of the session.
+    initiating_session: bool,
+}
+
+impl RequestCall {
+    pub fn new(
+        contact: NodeContact,
+        packet: Packet,
+        request: Request,
+        initiating_session: bool,
+    ) -> Self {
+        RequestCall {
+            contact,
+            packet,
+            request,
+            handshake_sent: false,
+            retries: 1,
+            remaining_responses: None,
+            initiating_session,
+        }
+    }
+
+    /// Returns the contact associated with this call.
+    pub fn contact(&self) -> &NodeContact {
+        &self.contact
+    }
+
+    /// Returns the id associated with this call.
+    pub fn id(&self) -> &RequestId {
+        &self.request.id
+    }
+
+    /// Returns the associated request for this call.
+    pub fn request(&self) -> &Request {
+        &self.request
+    }
+
+    /// Returns the packet associated with this call.
+    pub fn packet(&self) -> &Packet {
+        &self.packet
+    }
+
+    /// The number of times this request has been resent.
+    pub fn retries(&self) -> u8 {
+        self.retries
+    }
+
+    /// Increments the number of retries for this call
+    pub fn increment_retries(&mut self) {
+        self.retries += 1;
+    }
+
+    /// Returns whether the handshake has been sent for this call or not.
+    pub fn handshake_sent(&self) -> bool {
+        self.handshake_sent
+    }
+
+    /// Indicates the handshake has been sent.
+    pub fn set_handshake_sent(&mut self) {
+        self.handshake_sent = true;
+    }
+
+    /// Indicates a session has been initiated for this call.
+    pub fn set_initiating_session(&mut self, state: bool) {
+        self.initiating_session = state;
+    }
+
+    /// Returns whether a session is being initiated for this call.
+    pub fn initiating_session(&self) -> bool {
+        self.initiating_session
+    }
+
+    /// Updates the underlying packet for the call.
+    pub fn update_packet(&mut self, packet: Packet) {
+        self.packet = packet;
+    }
+
+    /// Gets a mutable reference to the remaining repsonses.
+    pub fn remaining_responses_mut(&mut self) -> &mut Option<u64> {
+        &mut self.remaining_responses
+    }
+}

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -247,7 +247,7 @@ async fn test_active_requests_insert() {
     let request_call = RequestCall::new(contact, packet, request, initiating_session);
 
     // insert the pair and verify the mapping remains in sync
-    let nonce = *request_call.packet.message_nonce();
+    let nonce = *request_call.packet().message_nonce();
     active_requests.insert(node_address, request_call);
     active_requests.check_invariant();
     active_requests.remove_by_nonce(&nonce);


### PR DESCRIPTION
Moves the request call struct into its own file to reduce excess logic in the handler