### PR TITLE
Separate handler requests from service requests

### DIFF
--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -2,7 +2,7 @@ use super::*;
 use delay_map::HashMapDelay;
 use more_asserts::debug_unreachable;
 
-pub(crate) struct ActiveRequests {
+pub(super) struct ActiveRequests {
     /// A list of raw messages we are awaiting a response from the remote.
     active_requests_mapping: HashMapDelay<NodeAddress, RequestCall>,
     // WHOAREYOU messages do not include the source node id. We therefore maintain another
@@ -13,14 +13,14 @@ pub(crate) struct ActiveRequests {
 }
 
 impl ActiveRequests {
-    pub(crate) fn new(request_timeout: Duration) -> Self {
+    pub fn new(request_timeout: Duration) -> Self {
         ActiveRequests {
             active_requests_mapping: HashMapDelay::new(request_timeout),
             active_requests_nonce_mapping: HashMap::new(),
         }
     }
 
-    pub(crate) fn insert(&mut self, node_address: NodeAddress, request_call: RequestCall) {
+    pub fn insert(&mut self, node_address: NodeAddress, request_call: RequestCall) {
         let nonce = *request_call.packet().message_nonce();
         self.active_requests_mapping
             .insert(node_address.clone(), request_call);
@@ -28,14 +28,11 @@ impl ActiveRequests {
             .insert(nonce, node_address);
     }
 
-    pub(crate) fn get(&self, node_address: &NodeAddress) -> Option<&RequestCall> {
+    pub fn get(&self, node_address: &NodeAddress) -> Option<&RequestCall> {
         self.active_requests_mapping.get(node_address)
     }
 
-    pub(crate) fn remove_by_nonce(
-        &mut self,
-        nonce: &MessageNonce,
-    ) -> Option<(NodeAddress, RequestCall)> {
+    pub fn remove_by_nonce(&mut self, nonce: &MessageNonce) -> Option<(NodeAddress, RequestCall)> {
         match self.active_requests_nonce_mapping.remove(nonce) {
             Some(node_address) => match self.active_requests_mapping.remove(&node_address) {
                 Some(request_call) => Some((node_address, request_call)),
@@ -49,7 +46,7 @@ impl ActiveRequests {
         }
     }
 
-    pub(crate) fn remove(&mut self, node_address: &NodeAddress) -> Option<RequestCall> {
+    pub fn remove(&mut self, node_address: &NodeAddress) -> Option<RequestCall> {
         match self.active_requests_mapping.remove(node_address) {
             Some(request_call) => {
                 // Remove the associated nonce mapping.
@@ -75,7 +72,7 @@ impl ActiveRequests {
     // this makes is so that if there is a panic, the error is printed in the caller of this
     // function.
     #[track_caller]
-    pub(crate) fn check_invariant(&self) {
+    pub fn check_invariant(&self) {
         // First check that for every `MessageNonce` there is an associated `NodeAddress`.
         for (nonce, address) in self.active_requests_nonce_mapping.iter() {
             if !self.active_requests_mapping.contains_key(address) {

--- a/src/handler/request_call.rs
+++ b/src/handler/request_call.rs
@@ -4,7 +4,7 @@ use crate::{
     rpc::{Request, RequestBody},
 };
 
-use super::RequestIdX;
+use super::HandlerReqId;
 
 /// A request to a node that we are waiting for a response.
 #[derive(Debug)]
@@ -13,7 +13,7 @@ pub(super) struct RequestCall {
     /// The raw discv5 packet sent.
     packet: Packet,
     /// Request id
-    request_id: RequestIdX,
+    request_id: HandlerReqId,
     /// The message body. Required if need to re-encrypt and re-send.
     request: RequestBody,
     /// Handshakes attempted.
@@ -32,7 +32,7 @@ impl RequestCall {
     pub fn new(
         contact: NodeContact,
         packet: Packet,
-        request_id: RequestIdX,
+        request_id: HandlerReqId,
         request: RequestBody,
         initiating_session: bool,
     ) -> Self {
@@ -54,7 +54,7 @@ impl RequestCall {
     }
 
     /// Returns the id associated with this call.
-    pub fn id(&self) -> &RequestIdX {
+    pub fn id(&self) -> &HandlerReqId {
         &self.request_id
     }
 
@@ -70,7 +70,7 @@ impl RequestCall {
 
     pub fn encode(&self) -> Vec<u8> {
         match &self.request_id {
-            RequestIdX::Internal(id) | RequestIdX::External(id) => {
+            HandlerReqId::Internal(id) | HandlerReqId::External(id) => {
                 let request = Request {
                     id: id.clone(),
                     body: self.request.clone(),

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -239,7 +239,7 @@ async fn test_active_requests_insert() {
     let node_address = contact.node_address();
 
     let packet = Packet::new_random(&node_id).unwrap();
-    let id = RequestIdX::Internal(RequestId::random());
+    let id = HandlerReqId::Internal(RequestId::random());
     let request = RequestBody::Ping { enr_seq: 1 };
     let initiating_session = true;
     let request_call = RequestCall::new(contact, packet, id, request, initiating_session);

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -239,12 +239,10 @@ async fn test_active_requests_insert() {
     let node_address = contact.node_address();
 
     let packet = Packet::new_random(&node_id).unwrap();
-    let request = Request {
-        id: RequestId(vec![1]),
-        body: RequestBody::Ping { enr_seq: 1 },
-    };
+    let id = RequestIdX::Internal(RequestId::random());
+    let request = RequestBody::Ping { enr_seq: 1 };
     let initiating_session = true;
-    let request_call = RequestCall::new(contact, packet, request, initiating_session);
+    let request_call = RequestCall::new(contact, packet, id, request, initiating_session);
 
     // insert the pair and verify the mapping remains in sync
     let nonce = *request_call.packet().message_nonce();


### PR DESCRIPTION
right now the handler does requests on itself to get the ENR of a multiaddr session. This makes it so that if this request fails/timeouts we don't report those failures to the service.

Notes:
- This will be needed to handle nat hole punching handler requests correctly
- Right now, the FINDNODE request for a multiaddr session can both fail and timeout without affecting the session itself. So it seems to be that the only purpose of requesting and obtaining the enr is adding a peer to our kbuckets on a `HandlerOut::Established` event. Not sure if this is intended but seemed notable to me.