### PR TITLE
Support configuring a different protocol id

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,14 @@ use crate::{
     ipmode::IpMode, kbucket::MAX_NODES_PER_BUCKET, Enr, Executor, PermitBanList, RateLimiter,
     RateLimiterBuilder,
 };
+use std::num::NonZeroU16;
 ///! A set of configuration parameters to tune the discovery protocol.
 use std::time::Duration;
+
+/// Protocol ID sent with each message.
+const DEFAULT_PROTOCOL_ID: &str = "discv5";
+/// The version sent with each handshake.
+const DEFAULT_PROTOCOL_VERSION: u16 = 0x0001;
 
 /// Configuration parameters that define the performance of the discovery network.
 #[derive(Clone)]
@@ -99,6 +105,9 @@ pub struct Discv5Config {
     /// A custom executor which can spawn the discv5 tasks. This must be a tokio runtime, with
     /// timing support. By default, the executor that created the discv5 struct will be used.
     pub executor: Option<Box<dyn Executor + Send + Sync>>,
+
+    /// The Discv5 protocol id and version.
+    pub protocol: (&'static str, u16),
 }
 
 impl Default for Discv5Config {
@@ -138,6 +147,7 @@ impl Default for Discv5Config {
             ban_duration: Some(Duration::from_secs(3600)), // 1 hour
             ip_mode: IpMode::default(),
             executor: None,
+            protocol: (DEFAULT_PROTOCOL_ID, DEFAULT_PROTOCOL_VERSION),
         }
     }
 }
@@ -314,10 +324,34 @@ impl Discv5ConfigBuilder {
         self
     }
 
+    /// Set the discv5 wire protocol id.
+    pub fn protocol_id(&mut self, protocol_id: &'static str) -> &mut Self {
+        if protocol_id.as_bytes().len() != 6 {
+            panic!("The protocol ID must be 6 bytes long");
+        }
+
+        self.config.protocol = (protocol_id, DEFAULT_PROTOCOL_VERSION);
+        self
+    }
+
+    /// Set the discv5 wire protocol id and the version.
+    pub fn protocol(
+        &mut self,
+        protocol_id: &'static str,
+        protocol_version: NonZeroU16,
+    ) -> &mut Self {
+        if protocol_id.as_bytes().len() != 6 {
+            panic!("The protocol ID must be 6 bytes long");
+        }
+
+        self.config.protocol = (protocol_id, protocol_version.get());
+        self
+    }
+
     pub fn build(&mut self) -> Discv5Config {
         // If an executor is not provided, assume a current tokio runtime is running.
         if self.config.executor.is_none() {
-            self.config.executor = Some(Box::new(crate::executor::TokioExecutor::default()));
+            self.config.executor = Some(Box::<crate::executor::TokioExecutor>::default());
         };
 
         assert!(self.config.incoming_bucket_limit <= MAX_NODES_PER_BUCKET);
@@ -347,6 +381,7 @@ impl std::fmt::Debug for Discv5Config {
             .field("incoming_bucket_limit", &self.incoming_bucket_limit)
             .field("ping_interval", &self.ping_interval)
             .field("ban_duration", &self.ban_duration)
+            .field("protocol", &self.protocol)
             .finish()
     }
 }

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -98,7 +98,7 @@ impl Discv5 {
 
         // If an executor is not provided, assume a current tokio runtime is running. If not panic.
         if config.executor.is_none() {
-            config.executor = Some(Box::new(crate::executor::TokioExecutor::default()));
+            config.executor = Some(Box::<crate::executor::TokioExecutor>::default());
         };
 
         // NOTE: Currently we don't expose custom filter support in the configuration. Users can

--- a/src/handler/crypto/mod.rs
+++ b/src/handler/crypto/mod.rs
@@ -391,10 +391,17 @@ mod tests {
 
     #[test]
     fn decrypt_ref_test_ping() {
+        /// Protocol ID sent with each message.
+        const DEFAULT_PROTOCOL_ID: &str = "discv5";
+        /// The version sent with each handshake.
+        const DEFAULT_PROTOCOL_VERSION: u16 = 0x0001;
+
+        let protocol = (DEFAULT_PROTOCOL_ID, DEFAULT_PROTOCOL_VERSION);
+
         let dst_id: NodeId = node_key_2().public().into();
         let encoded_ref_packet = hex::decode("00000000000000000000000000000000088b3d4342774649325f313964a39e55ea96c005ad52be8c7560413a7008f16c9e6d2f43bbea8814a546b7409ce783d34c4f53245d08dab84102ed931f66d1492acb308fa1c6715b9d139b81acbdcc").unwrap();
         let (_packet, auth_data) =
-            crate::packet::Packet::decode(&dst_id, &encoded_ref_packet).unwrap();
+            crate::packet::Packet::decode(protocol, &dst_id, &encoded_ref_packet).unwrap();
 
         let ciphertext = hex::decode("b84102ed931f66d1492acb308fa1c6715b9d139b81acbdcc").unwrap();
         let read_key = hex::decode("00000000000000000000000000000000").unwrap();

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -22,6 +22,11 @@ macro_rules! arc_rw {
     };
 }
 
+/// Protocol ID sent with each message.
+const DEFAULT_PROTOCOL_ID: &str = "discv5";
+/// The version sent with each handshake.
+const DEFAULT_PROTOCOL_VERSION: u16 = 0x0001;
+
 #[tokio::test]
 // Tests the construction and sending of a simple message
 async fn simple_session_message() {
@@ -221,6 +226,7 @@ async fn multiple_messages() {
 async fn test_active_requests_insert() {
     const EXPIRY: Duration = Duration::from_secs(5);
     let mut active_requests = ActiveRequests::new(EXPIRY);
+    let protocol = (DEFAULT_PROTOCOL_ID, DEFAULT_PROTOCOL_VERSION);
 
     // Create the test values needed
     let port = 5000;
@@ -238,7 +244,7 @@ async fn test_active_requests_insert() {
     let contact: NodeContact = enr.into();
     let node_address = contact.node_address();
 
-    let packet = Packet::new_random(&node_id).unwrap();
+    let packet = Packet::new_random(protocol, &node_id).unwrap();
     let id = HandlerReqId::Internal(RequestId::random());
     let request = RequestBody::Ping { enr_seq: 1 };
     let initiating_session = true;

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -1,6 +1,10 @@
 #![cfg(test)]
 
-use super::*;
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+
+use enr::{CombinedKey, EnrBuilder};
+use parking_lot::RwLock;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{
     handler::Handler,
@@ -12,10 +16,8 @@ use crate::{
     service::{ActiveRequest, Service},
     Discv5ConfigBuilder, Enr,
 };
-use enr::{CombinedKey, EnrBuilder};
-use parking_lot::RwLock;
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
-use tokio::sync::{mpsc, oneshot};
+
+use super::*;
 
 fn _connected_state() -> NodeStatus {
     NodeStatus {
@@ -44,7 +46,7 @@ async fn build_service(
     filters: bool,
 ) -> Service {
     let config = Discv5ConfigBuilder::new()
-        .executor(Box::new(crate::executor::TokioExecutor::default()))
+        .executor(Box::<crate::executor::TokioExecutor>::default())
         .build();
     // build the session service
     let (_handler_exit, handler_send, handler_recv) = Handler::spawn(

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -25,6 +25,8 @@ pub use send::OutboundPacket;
 
 /// Convenience objects for setting up the recv handler.
 pub struct SocketConfig {
+    /// The Discv5 protocol id and version.
+    pub protocol: (&'static str, u16),
     /// The executor to spawn the tasks.
     pub executor: Box<dyn Executor + Send + Sync>,
     /// The listening socket.
@@ -96,6 +98,7 @@ impl Socket {
 
         // spawn the recv handler
         let recv_config = RecvHandlerConfig {
+            protocol: config.protocol,
             filter_config: config.filter_config,
             executor: config.executor.clone(),
             recv: recv_udp,


### PR DESCRIPTION
To make _rust-waku_ compatible with the Waku reference implementation, I added support to this crate to configure the protocol ID.

This PR resolves #154 

- [x] Add the `protocol` field to `Discv5Config`.
  + The protocol ID and the protocol version values default to the specification values, `discv5` and `0x0001`, respectively.
- [x] Add a matching `protocol_id` function to the `Discv5ConfigBuilder`. 
  + The configuration builder panics if the provided protocol ID has a length different than 6 bytes.
- [x] Add a `protocol_id` and `protocol_version` fields to `packet::{Packet, PacketHeader}`.
- [x] ~~Encapsulate the `packet::Packet` codec logic to support checking the message validity against non-constant (non-static) values.~~
- [x] Add support for checking the message validity against the configured values.
