### PR TITLE
Update `enr` crate version and add `serde` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.6.2", features = ["k256", "ed25519"] }
+enr = { version = "0.7.0", features = ["k256", "ed25519"] }
 tokio = { version = "1.15.0", features = ["net", "sync", "macros", "rt"] }
 tokio-stream = "0.1.8"
 tokio-util = { version = "0.6.9", features = ["time"] }
@@ -54,3 +54,4 @@ clap = { version = "3.1", features = ["derive"] }
 
 [features]
 libp2p = ["libp2p-core"]
+serde = ["enr/serde"]


### PR DESCRIPTION
I think it will be nice if `discv5` imports the `enr` crate with the `serde` feature, This allows Serialization/Deserialization of the `discv5::Enr` type out of the box.