### PR TITLE
ci: expand and fix checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install protobuf compiler for the libp2p-core dependency
         uses: arduino/setup-protoc@v1
       - name: Run tests in release
-        run: cargo test --all --release --all-features --tests
+        run: cargo test --all --release --all-features
   check-rustdoc-links:
     name: Check rustdoc intra-doc links
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get latest version of stable rust
         run: rustup update stable
       - name: Run tests in release
-        run: cargo test --all --release --tests
+        run: cargo test --all --release
   test-all-features:
     runs-on: ubuntu-latest
     container:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A simple example of creating this service is as follows:
    let config = Discv5ConfigBuilder::new().build();
 
    // construct the discv5 server
-   let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
+   let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 
    // In order to bootstrap the routing table an external ENR should be added
    // This can be done via add_enr. I.e.:

--- a/examples/request_enr.rs
+++ b/examples/request_enr.rs
@@ -46,7 +46,7 @@ async fn main() {
         .expect("A multiaddr must be supplied");
 
     // construct the discv5 server
-    let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
+    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 
     // start the discv5 service
     discv5.start(listen_addr).await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //!    let config = Discv5ConfigBuilder::new().build();
 //!
 //!    // construct the discv5 server
-//!    let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
+//!    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 //!
 //!    // In order to bootstrap the routing table an external ENR should be added
 //!    // This can be done via add_enr. I.e.:


### PR DESCRIPTION
The flag `--tests` limits the `cargo test` to the tests, leaving behind the doctests, and it seems to be the examples as well.
This removes this flag to expand ci and fixes the failing checks