### PR TITLE
Update tcp socket correctly

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -384,35 +384,29 @@ impl Discv5 {
     /// Updates the local ENR TCP/UDP socket.
     pub fn update_local_enr_socket(&self, socket_addr: SocketAddr, is_tcp: bool) -> bool {
         let mut local_enr = self.local_enr.write();
-        let update_socket: Option<SocketAddr> = match socket_addr {
-            SocketAddr::V4(socket_addr) => {
-                if Some(socket_addr) != local_enr.udp4_socket() {
-                    Some(socket_addr.into())
-                } else {
-                    None
+        match (is_tcp, socket_addr) {
+            (false, SocketAddr::V4(specific_socket_addr)) => {
+                if Some(specific_socket_addr) != local_enr.udp4_socket() {
+                    return local_enr.set_udp_socket(socket_addr, &self.enr_key.read()).is_ok();
                 }
             }
-            SocketAddr::V6(socket_addr) => {
-                if Some(socket_addr) != local_enr.udp6_socket() {
-                    Some(socket_addr.into())
-                } else {
-                    None
+            (true, SocketAddr::V4(specific_socket_addr)) => {
+                if Some(specific_socket_addr) != local_enr.tcp4_socket() {
+                    return local_enr.set_tcp_socket(socket_addr, &self.enr_key.read()).is_ok();
                 }
             }
-        };
-        if let Some(new_socket_addr) = update_socket {
-            if is_tcp {
-                local_enr
-                    .set_tcp_socket(new_socket_addr, &self.enr_key.read())
-                    .is_ok()
-            } else {
-                local_enr
-                    .set_udp_socket(new_socket_addr, &self.enr_key.read())
-                    .is_ok()
+            (false, SocketAddr::V6(specific_socket_addr)) => {
+                if Some(specific_socket_addr) != local_enr.udp6_socket() {
+                    return local_enr.set_udp_socket(socket_addr, &self.enr_key.read()).is_ok();
+                }
             }
-        } else {
-            false
+            (true, SocketAddr::V6(specific_socket_addr)) => {
+                if Some(specific_socket_addr) != local_enr.tcp6_socket() {
+                    return local_enr.set_tcp_socket(socket_addr, &self.enr_key.read()).is_ok();
+                }
+            }
         }
+        false
     }
 
     /// Allows application layer to insert an arbitrary field into the local ENR.

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -387,22 +387,30 @@ impl Discv5 {
         match (is_tcp, socket_addr) {
             (false, SocketAddr::V4(specific_socket_addr)) => {
                 if Some(specific_socket_addr) != local_enr.udp4_socket() {
-                    return local_enr.set_udp_socket(socket_addr, &self.enr_key.read()).is_ok();
+                    return local_enr
+                        .set_udp_socket(socket_addr, &self.enr_key.read())
+                        .is_ok();
                 }
             }
             (true, SocketAddr::V4(specific_socket_addr)) => {
                 if Some(specific_socket_addr) != local_enr.tcp4_socket() {
-                    return local_enr.set_tcp_socket(socket_addr, &self.enr_key.read()).is_ok();
+                    return local_enr
+                        .set_tcp_socket(socket_addr, &self.enr_key.read())
+                        .is_ok();
                 }
             }
             (false, SocketAddr::V6(specific_socket_addr)) => {
                 if Some(specific_socket_addr) != local_enr.udp6_socket() {
-                    return local_enr.set_udp_socket(socket_addr, &self.enr_key.read()).is_ok();
+                    return local_enr
+                        .set_udp_socket(socket_addr, &self.enr_key.read())
+                        .is_ok();
                 }
             }
             (true, SocketAddr::V6(specific_socket_addr)) => {
                 if Some(specific_socket_addr) != local_enr.tcp6_socket() {
-                    return local_enr.set_tcp_socket(socket_addr, &self.enr_key.read()).is_ok();
+                    return local_enr
+                        .set_tcp_socket(socket_addr, &self.enr_key.read())
+                        .is_ok();
                 }
             }
         }


### PR DESCRIPTION
The API prevented users from updating the TCP port in the ENR to match the current UDP socket. 

This corrects the logic and allows users to update the tcp port if needed.