### PR TITLE
Update to ENR v0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.7.0", features = ["k256", "ed25519"] }
+enr = { version = "0.8.1", features = ["k256", "ed25519"] }
 tokio = { version = "1.15.0", features = ["net", "sync", "macros", "rt"] }
 tokio-stream = "0.1.8"
 tokio-util = { version = "0.6.9", features = ["time"] }

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -73,7 +73,7 @@ async fn main() {
         let raw_key =
             hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
                 .unwrap();
-        let secret_key = k256::ecdsa::SigningKey::from_bytes(&raw_key).unwrap();
+        let secret_key = k256::ecdsa::SigningKey::from_slice(&raw_key).unwrap();
         CombinedKey::from(secret_key)
     } else {
         // use a new key if specified

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -393,7 +393,7 @@ impl<P: ProtocolIdentity> Discv5<P> {
     }
 
     /// Allows application layer to insert an arbitrary field into the local ENR.
-    pub fn enr_insert(&self, key: &str, value: &[u8]) -> Result<Option<Vec<u8>>, EnrError> {
+    pub fn enr_insert<T: rlp::Encodable>(&self, key: &str, value: &T) -> Result<Option<Vec<u8>>, EnrError> {
         self.local_enr
             .write()
             .insert(key, value, &self.enr_key.read())

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -393,7 +393,11 @@ impl<P: ProtocolIdentity> Discv5<P> {
     }
 
     /// Allows application layer to insert an arbitrary field into the local ENR.
-    pub fn enr_insert<T: rlp::Encodable>(&self, key: &str, value: &T) -> Result<Option<Vec<u8>>, EnrError> {
+    pub fn enr_insert<T: rlp::Encodable>(
+        &self,
+        key: &str,
+        value: &T,
+    ) -> Result<Option<Vec<u8>>, EnrError> {
         self.local_enr
             .write()
             .insert(key, value, &self.enr_key.read())

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -11,7 +11,7 @@ fn init() {
         .try_init();
 }
 
-fn update_enr(discv5: &mut Discv5, key: &str, value: &[u8]) -> bool {
+fn update_enr<T: rlp::Encodable>(discv5: &mut Discv5, key: &str, value: &T) -> bool {
     discv5.enr_insert(key, value).is_ok()
 }
 
@@ -72,7 +72,7 @@ fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
             loop {
                 // until a value is given within the curve order
                 rng.fill_bytes(&mut b);
-                if let Ok(k) = k256::ecdsa::SigningKey::from_bytes(&b) {
+                if let Ok(k) = k256::ecdsa::SigningKey::from_slice(&b) {
                     break k;
                 }
             }

--- a/src/handler/crypto/ecdh.rs
+++ b/src/handler/crypto/ecdh.rs
@@ -7,10 +7,10 @@ use super::k256::{
 
 pub fn ecdh(public_key: &VerifyingKey, secret_key: &SigningKey) -> Vec<u8> {
     k256::PublicKey::from_affine(
-        (k256::PublicKey::from_sec1_bytes(public_key.to_bytes().as_ref())
+        (k256::PublicKey::from_sec1_bytes(public_key.to_sec1_bytes().as_ref())
             .unwrap()
             .to_projective()
-            * k256::SecretKey::from_be_bytes(&secret_key.to_bytes())
+            * k256::SecretKey::from_slice(&secret_key.to_bytes())
                 .unwrap()
                 .to_nonzero_scalar()
                 .as_ref())

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -117,9 +117,11 @@ impl NodeContact {
                         .expect("Libp2p key conversion, always valid")
                         .into()
                 }
-                PublicKey::Ed25519(pk) => enr::ed25519_dalek::PublicKey::from_bytes(&pk.encode())
-                    .expect("Libp2p key conversion, always valid")
-                    .into(),
+                PublicKey::Ed25519(pk) => {
+                    enr::ed25519_dalek::VerifyingKey::from_bytes(&pk.encode())
+                        .expect("Libp2p key conversion, always valid")
+                        .into()
+                }
                 _ => return Err("The key type is not supported"),
             };
 


### PR DESCRIPTION
This updates to the latest version of ENR. 

This change updates the underlying crypto libraries as well as some encoding improvements. 

This does create a breaking API change also. 

This resolves #171 