### PR TITLE
Respond to a PING even if the source doesn't match the ENR

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,12 @@ pub struct Discv5Config {
     /// The maximum number of established sessions to maintain. Default: 1000.
     pub session_cache_capacity: usize,
 
+    /// The one-time session timeout. Default: 30 seconds.
+    pub one_time_session_timeout: Duration,
+
+    /// The maximum number of established one-time sessions to maintain. Default: 100.
+    pub one_time_session_cache_capacity: usize,
+
     /// Updates the local ENR IP and port based on PONG responses from peers. Default: true.
     pub enr_update: bool,
 
@@ -127,6 +133,8 @@ impl Discv5ConfigBuilder {
             request_retries: 1,
             session_timeout: Duration::from_secs(86400),
             session_cache_capacity: 1000,
+            one_time_session_timeout: Duration::from_secs(30),
+            one_time_session_cache_capacity: 100,
             enr_update: true,
             max_nodes_response: 16,
             enr_peer_update_min: 10,
@@ -196,6 +204,18 @@ impl Discv5ConfigBuilder {
     /// The maximum number of established sessions to maintain.
     pub fn session_cache_capacity(&mut self, capacity: usize) -> &mut Self {
         self.config.session_cache_capacity = capacity;
+        self
+    }
+
+    /// The one-time session timeout.
+    pub fn one_time_session_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.config.one_time_session_timeout = timeout;
+        self
+    }
+
+    /// The maximum number of established one-time sessions to maintain.
+    pub fn one_time_session_cache_capacity(&mut self, capacity: usize) -> &mut Self {
+        self.config.one_time_session_cache_capacity = capacity;
         self
     }
 
@@ -325,6 +345,11 @@ impl std::fmt::Debug for Discv5Config {
             .field("request_retries", &self.request_retries)
             .field("session_timeout", &self.session_timeout)
             .field("session_cache_capacity", &self.session_cache_capacity)
+            .field("one_time_session_timeout", &self.one_time_session_timeout)
+            .field(
+                "one_time_session_cache_capacity",
+                &self.one_time_session_cache_capacity,
+            )
             .field("enr_update", &self.enr_update)
             .field("query_parallelism", &self.query_parallelism)
             .field("report_discovered_peers", &self.report_discovered_peers)

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,12 +35,6 @@ pub struct Discv5Config {
     /// The maximum number of established sessions to maintain. Default: 1000.
     pub session_cache_capacity: usize,
 
-    /// The one-time session timeout. Default: 30 seconds.
-    pub one_time_session_timeout: Duration,
-
-    /// The maximum number of established one-time sessions to maintain. Default: 100.
-    pub one_time_session_cache_capacity: usize,
-
     /// Updates the local ENR IP and port based on PONG responses from peers. Default: true.
     pub enr_update: bool,
 
@@ -133,8 +127,6 @@ impl Discv5ConfigBuilder {
             request_retries: 1,
             session_timeout: Duration::from_secs(86400),
             session_cache_capacity: 1000,
-            one_time_session_timeout: Duration::from_secs(30),
-            one_time_session_cache_capacity: 100,
             enr_update: true,
             max_nodes_response: 16,
             enr_peer_update_min: 10,
@@ -204,18 +196,6 @@ impl Discv5ConfigBuilder {
     /// The maximum number of established sessions to maintain.
     pub fn session_cache_capacity(&mut self, capacity: usize) -> &mut Self {
         self.config.session_cache_capacity = capacity;
-        self
-    }
-
-    /// The one-time session timeout.
-    pub fn one_time_session_timeout(&mut self, timeout: Duration) -> &mut Self {
-        self.config.one_time_session_timeout = timeout;
-        self
-    }
-
-    /// The maximum number of established one-time sessions to maintain.
-    pub fn one_time_session_cache_capacity(&mut self, capacity: usize) -> &mut Self {
-        self.config.one_time_session_cache_capacity = capacity;
         self
     }
 
@@ -345,11 +325,6 @@ impl std::fmt::Debug for Discv5Config {
             .field("request_retries", &self.request_retries)
             .field("session_timeout", &self.session_timeout)
             .field("session_cache_capacity", &self.session_cache_capacity)
-            .field("one_time_session_timeout", &self.one_time_session_timeout)
-            .field(
-                "one_time_session_cache_capacity",
-                &self.one_time_session_cache_capacity,
-            )
             .field("enr_update", &self.enr_update)
             .field("query_parallelism", &self.query_parallelism)
             .field("report_discovered_peers", &self.report_discovered_peers)

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -283,8 +283,10 @@ impl Handler {
                         config.session_timeout,
                         Some(config.session_cache_capacity),
                     ),
-                    // TODO: config
-                    one_time_sessions: LruTimeCache::new(Duration::from_secs(30), Some(50)),
+                    one_time_sessions: LruTimeCache::new(
+                        config.one_time_session_timeout,
+                        Some(config.one_time_session_cache_capacity),
+                    ),
                     active_challenges: HashMapDelay::new(config.request_timeout),
                     service_recv,
                     service_send,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -844,7 +844,7 @@ impl Handler {
                         };
                         if let Some(request) = maybe_ping_request {
                             debug!(
-                                "Responding PING request using one-time session. node_address: {}",
+                                "Responding to a PING request using a one-time session. node_address: {}",
                                 node_address
                             );
                             self.one_time_sessions

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -73,6 +73,12 @@ use session::Session;
 // seconds).
 const BANNED_NODES_CHECK: u64 = 300; // Check every 5 minutes.
 
+// The one-time session timeout.
+const ONE_TIME_SESSION_TIMEOUT: u64 = 30;
+
+// The maximum number of established one-time sessions to maintain.
+const ONE_TIME_SESSION_CACHE_CAPACITY: usize = 100;
+
 /// Messages sent from the application layer to `Handler`.
 #[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
@@ -284,8 +290,8 @@ impl Handler {
                         Some(config.session_cache_capacity),
                     ),
                     one_time_sessions: LruTimeCache::new(
-                        config.one_time_session_timeout,
-                        Some(config.one_time_session_cache_capacity),
+                        Duration::from_secs(ONE_TIME_SESSION_TIMEOUT),
+                        Some(ONE_TIME_SESSION_CACHE_CAPACITY),
                     ),
                     active_challenges: HashMapDelay::new(config.request_timeout),
                     service_recv,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -857,10 +857,11 @@ impl Handler {
                                 .insert(node_address.clone(), (request.id.clone(), session));
                             if let Err(e) = self
                                 .service_send
-                                .send(HandlerOut::Request(node_address, Box::new(request)))
+                                .send(HandlerOut::Request(node_address.clone(), Box::new(request)))
                                 .await
                             {
-                                warn!("Failed to report request to application {}", e)
+                                warn!("Failed to report request to application {}", e);
+                                self.one_time_sessions.remove(&node_address);
                             }
                         }
                     }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -843,16 +843,16 @@ impl Handler {
                             },
                             _ => None,
                         };
-                        if let Some(reqeust) = maybe_ping_request {
+                        if let Some(request) = maybe_ping_request {
                             debug!(
                                 "Responding PING request using one-time session. node_address: {}",
                                 node_address
                             );
                             self.one_time_sessions
-                                .insert((node_address.clone(), reqeust.id.clone()), session);
+                                .insert((node_address.clone(), request.id.clone()), session);
                             if let Err(e) = self
                                 .service_send
-                                .send(HandlerOut::Request(node_address.clone(), Box::new(reqeust)))
+                                .send(HandlerOut::Request(node_address.clone(), Box::new(request)))
                                 .await
                             {
                                 warn!("Failed to report request to application {}", e)

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -191,7 +191,7 @@ pub struct Handler {
     active_challenges: HashMapDelay<NodeAddress, Challenge>,
     /// Established sessions with peers.
     sessions: LruTimeCache<NodeAddress, Session>,
-    /// Established sessions with peers for a specific request.
+    /// Established sessions with peers for a specific request, stored just one per node.
     one_time_sessions: LruTimeCache<NodeAddress, (RequestId, Session)>,
     /// The channel to receive messages from the application layer.
     service_recv: mpsc::UnboundedReceiver<HandlerIn>,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1162,7 +1162,7 @@ impl Handler {
         node_address: &NodeAddress,
         request_id: &RequestId,
     ) -> Option<Session> {
-        match self.one_time_sessions.get(node_address) {
+        match self.one_time_sessions.peek(node_address) {
             Some((id, _)) if id == request_id => {
                 let (_, session) = self
                     .one_time_sessions

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -536,7 +536,7 @@ impl Handler {
 
         match packet {
             Ok(packet) => self.send(node_address, packet).await,
-            Err(e) => return warn!("Could not encrypt response: {:?}", e),
+            Err(e) => warn!("Could not encrypt response: {:?}", e),
         }
     }
 
@@ -1166,7 +1166,7 @@ impl Handler {
             Some((id, _)) if id == request_id => {
                 let (_, session) = self
                     .one_time_sessions
-                    .remove(&node_address)
+                    .remove(node_address)
                     .expect("one-time session must exist");
                 Some(session)
             }

--- a/src/handler/session.rs
+++ b/src/handler/session.rs
@@ -265,3 +265,11 @@ impl Session {
         Ok((packet, session))
     }
 }
+
+#[cfg(test)]
+pub(crate) fn build_dummy_session() -> Session {
+    Session::new(Keys {
+        encryption_key: [0; 16],
+        decryption_key: [0; 16],
+    })
+}

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -72,8 +72,8 @@ async fn build_handler<P: ProtocolIdentity>() -> Handler {
         filter_expected_responses,
         sessions: LruTimeCache::new(config.session_timeout, Some(config.session_cache_capacity)),
         one_time_sessions: LruTimeCache::new(
-            config.one_time_session_timeout,
-            Some(config.one_time_session_cache_capacity),
+            Duration::from_secs(ONE_TIME_SESSION_TIMEOUT),
+            Some(ONE_TIME_SESSION_CACHE_CAPACITY),
         ),
         active_challenges: HashMapDelay::new(config.request_timeout),
         service_recv,


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

Our discv5 implementation drops a request if the source IP address doesn't match the ENR. For PING request, due to this behaviour, the source node can't notice that its external IP address has been changed.

Here is a simulation that reproduce that issue. 
https://github.com/ackintosh/discv5-testground/pull/98

This PR makes discv5 to respond PING even if the source IP address doesn't match.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

### one-time sessions

I introduced **one-time session** at handler to encrypt PONG response without storing a (normal) session. One-time session here is a session for a specific request such that a PING request mentioned above. As the name implies, one-time session is removed once it's used.

### New config parameters

Added config parameters for one-time session introduced by this PR.

- one_time_session_timeout
- one_time_session_cache_capacity

These are similar to the parameters for normal sessions, but the default values are set to 30 seconds, and 100 respectively.

### Simulation test for this PR

Also I have created a Testground test plan that simulates IP changes. 
https://github.com/ackintosh/discv5-testground/pull/98

The result is fine. Here is a sequence diagram that illustrates how this change behaves on IP changes.

```mermaid
sequenceDiagram
    participant Node1
    participant Node2 ... Node N

    rect rgb(10, 10, 10)
    Note left of Node1: They communicate with each other<br> to establish a session.
    Note over Node1,Node2 ... Node N: Session established
    end

    rect rgb(10, 10, 10)
    Note left of Node1: Node1 changes its IP address<br> but doesn't update its ENR.
    Note over Node1: *** Change its IP address ***
    end

    Node1 ->> Node2 ... Node N: PING
    Note over Node2 ... Node N: No session with the new IP exists
    Node2 ... Node N ->> Node1: WHOAREYOU
    Note over Node1: Establish new session
    Node1 ->> Node2 ... Node N: Auth message<br> (The ENR record has the old IP)
    Note over Node2 ... Node N: `verify_enr()` results in false<br> as the ENR and src IP don't match.
    Note over Node2 ... Node N: Establish one-time session with Node1's new IP
    
    rect rgb(0, 255, 0)
    Note over Node2 ... Node N: Respond the PING using the one-time session
    end

    Node2 ... Node N ->> Node1: PONG

    rect rgb(0, 255, 0)
    Note over Node1: Update local ENR to the new IP via the IpVote process.
    end

    Node1 ->> Node2 ... Node N: PING
    Note over Node2 ... Node N: No (normal) session with the new IP exists
    Node2 ... Node N ->> Node1: WHOAREYOU
    Note over Node1: Establish new session
    Node1 ->> Node2 ... Node N: Auth message<br> (The ENR record has the new IP)

    Note over Node2 ... Node N: `verify_enr()` results in true here
    rect rgb(0, 255, 0)
    Note over Node2 ... Node N: Establish new (normal) session
    end

    Node2 ... Node N ->> Node1: PONG
```

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
