### PR TITLE
Appease clippy in Rust 1.70

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
+//! A set of configuration parameters to tune the discovery protocol.
 use crate::{
     kbucket::MAX_NODES_PER_BUCKET, socket::ListenConfig, Enr, Executor, PermitBanList, RateLimiter,
     RateLimiterBuilder,
 };
-///! A set of configuration parameters to tune the discovery protocol.
 use std::time::Duration;
 
 /// Configuration parameters that define the performance of the discovery network.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,6 +1,5 @@
-///! A simple trait to allow generic executors or wrappers for spawning the discv5 tasks.
-use std::future::Future;
-use std::pin::Pin;
+//! A simple trait to allow generic executors or wrappers for spawning the discv5 tasks.
+use std::{future::Future, pin::Pin};
 
 pub trait Executor: ExecutorClone {
     /// Run the given future in the background until it ends.

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -1,11 +1,10 @@
+//! A set of configuration parameters to tune the discovery protocol.
 use crate::{
     socket::ListenConfig,
     Enr,
     IpMode::{DualStack, Ip4, Ip6},
 };
 use std::net::SocketAddr;
-
-///! A set of configuration parameters to tune the discovery protocol.
 
 /// Sets the socket type to be established and also determines the type of ENRs that we will store
 /// in our routing table.


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

Fixed some new clippy lints raised after updating to Rust 1.70.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

The errors that were happened are here:

```
error: this is an outer doc comment and does not apply to the parent module or crate
 --> src/config.rs:5:1
  |
5 | ///! A set of configuration parameters to tune the discovery protocol.
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_doc_comments
  = note: `-D clippy::suspicious-doc-comments` implied by `-D warnings`
help: use an inner doc comment to document the parent module or crate
  |
5 | //! A set of configuration parameters to tune the discovery protocol.
  |

error: this is an outer doc comment and does not apply to the parent module or crate
 --> src/executor.rs:1:1
  |
1 | ///! A simple trait to allow generic executors or wrappers for spawning the discv5 tasks.
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_doc_comments
help: use an inner doc comment to document the parent module or crate
  |
1 | //! A simple trait to allow generic executors or wrappers for spawning the discv5 tasks.
  |

error: this is an outer doc comment and does not apply to the parent module or crate
 --> src/ipmode.rs:8:1
  |
8 | ///! A set of configuration parameters to tune the discovery protocol.
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_doc_comments
help: use an inner doc comment to document the parent module or crate
  |
8 | //! A set of configuration parameters to tune the discovery protocol.
  |
```


## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
