### PR TITLE
Fix unexpected ConnectionDirection update

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -113,7 +113,7 @@ pub enum HandlerOut {
     /// A session is only considered established once we have received a signed ENR from the
     /// node and either the observed `SocketAddr` matches the one declared in the ENR or the
     /// ENR declares no `SocketAddr`.
-    Established(Enr, SocketAddr, ConnectionUpdate),
+    Established(Enr, SocketAddr, ConnectionDirection),
 
     /// A Request has been received from a node on the network.
     Request(NodeAddress, Box<Request>),
@@ -138,17 +138,6 @@ pub enum ConnectionDirection {
     Incoming,
     /// We contacted the node.
     Outgoing,
-}
-
-/// An instruction from the handler to the service how to update the connection direction.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ConnectionUpdate {
-    /// Incoming.
-    Incoming,
-    /// Outgoing.
-    Outgoing,
-    /// If there is an established connection keep it; if not Incoming.
-    IncomingIfNotExists,
 }
 
 /// A reference for the application layer to send back when the handler requests any known
@@ -693,12 +682,10 @@ impl Handler {
                 // outgoing session is that we originally sent a RANDOM packet (signifying we did
                 // not have a session for a request) and the packet is not a PING (we are not
                 // trying to update an old session that may have expired.
-                let connection_update = {
-                    match (request_call.initiating_session(), &request_call.body()) {
-                        (true, RequestBody::Ping { .. }) => ConnectionUpdate::Incoming,
-                        (true, _) => ConnectionUpdate::Outgoing,
-                        (false, _) => ConnectionUpdate::IncomingIfNotExists,
-                    }
+                let connection_direction = if request_call.initiating_session() {
+                    ConnectionDirection::Outgoing
+                } else {
+                    ConnectionDirection::Incoming
                 };
 
                 // We already know the ENR. Send the handshake response packet
@@ -716,7 +703,7 @@ impl Handler {
                     .send(HandlerOut::Established(
                         enr,
                         node_address.socket_addr,
-                        connection_update,
+                        connection_direction,
                     ))
                     .await
                     .unwrap_or_else(|e| warn!("Error with sending channel: {}", e));
@@ -806,7 +793,7 @@ impl Handler {
                             .send(HandlerOut::Established(
                                 enr,
                                 node_address.socket_addr,
-                                ConnectionUpdate::Incoming,
+                                ConnectionDirection::Incoming,
                             ))
                             .await
                         {
@@ -987,7 +974,7 @@ impl Handler {
                                                 .send(HandlerOut::Established(
                                                     enr,
                                                     node_address.socket_addr,
-                                                    ConnectionUpdate::Outgoing,
+                                                    ConnectionDirection::Outgoing,
                                                 ))
                                                 .await
                                             {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -695,7 +695,9 @@ impl Handler {
                 // trying to update an old session that may have expired.
                 let connection_direction_instruction = {
                     match (request_call.initiating_session(), &request_call.body()) {
-                        (true, RequestBody::Ping { .. }) => ConnectionDirectionInstruction::Incoming,
+                        (true, RequestBody::Ping { .. }) => {
+                            ConnectionDirectionInstruction::Incoming
+                        }
                         (true, _) => ConnectionDirectionInstruction::Outgoing,
                         (false, _) => ConnectionDirectionInstruction::IncomingIfNotExists,
                     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1370,7 +1370,11 @@ impl Service {
 
     /// The equivalent of libp2p `inject_connected()` for a udp session. We have no stream, but a
     /// session key-pair has been negotiated.
-    fn inject_session_established(&mut self, enr: Enr, direction_instruction: ConnectionDirectionInstruction) {
+    fn inject_session_established(
+        &mut self,
+        enr: Enr,
+        direction_instruction: ConnectionDirectionInstruction,
+    ) {
         // Ignore sessions with non-contactable ENRs
         if self.ip_mode.get_contactable_addr(&enr).is_none() {
             return;
@@ -1384,7 +1388,7 @@ impl Service {
             ConnectionDirectionInstruction::IncomingIfNotExists => {
                 let key = kbucket::Key::from(node_id.clone());
                 match self.kbuckets.write().entry(&key) {
-                    Entry::Present(_, status) if status.is_connected() => { status.direction }
+                    Entry::Present(_, status) if status.is_connected() => status.direction,
                     _ => ConnectionDirection::Incoming,
                 }
             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1377,7 +1377,7 @@ impl Service {
         let node_id = enr.node_id();
 
         // We never update connection direction if a node already exists in the routing table as we
-        // don't want to promote the direction like from incoming to outgoing.
+        // don't want to promote the direction from incoming to outgoing.
         let key = kbucket::Key::from(node_id);
         let direction = match self
             .kbuckets

--- a/src/service.rs
+++ b/src/service.rs
@@ -1384,7 +1384,7 @@ impl Service {
             ConnectionDirectionInstruction::Incoming => ConnectionDirection::Incoming,
             ConnectionDirectionInstruction::Outgoing => ConnectionDirection::Outgoing,
             ConnectionDirectionInstruction::IncomingIfNotExists => {
-                let key = kbucket::Key::from(node_id.clone());
+                let key = kbucket::Key::from(node_id);
                 match self.kbuckets.write().entry(&key) {
                     Entry::Present(_, status) if status.is_connected() => status.direction,
                     _ => ConnectionDirection::Incoming,

--- a/src/service.rs
+++ b/src/service.rs
@@ -164,9 +164,7 @@ pub enum ServiceRequest {
     RequestEventStream(oneshot::Sender<mpsc::Receiver<Discv5Event>>),
 }
 
-use crate::discv5::PERMIT_BAN_LIST;
-use crate::handler::ConnectionDirectionInstruction;
-use crate::kbucket::Entry;
+use crate::{discv5::PERMIT_BAN_LIST, handler::ConnectionDirectionInstruction, kbucket::Entry};
 
 pub struct Service {
     /// Configuration parameters.

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -178,7 +178,7 @@ async fn test_updating_connection_direction_on_new_session() {
         .unwrap();
 
     let enr_key2 = CombinedKey::generate_secp256k1();
-    let ip2 = "127.0.0.1".parse().unwrap();
+    let ip2 = std::net::Ipv4Addr::LOCALHOST;
     let enr2 = EnrBuilder::new("v4")
         .ip4(ip2)
         .udp4(10002)

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -170,7 +170,7 @@ async fn test_updating_connection_direction_on_new_session() {
     init();
 
     let enr_key1 = CombinedKey::generate_secp256k1();
-    let ip = "127.0.0.1".parse().unwrap();
+    let ip = std::net::Ipv4Addr::LOCALHOST;
     let enr = EnrBuilder::new("v4")
         .ip4(ip)
         .udp4(10001)

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -193,31 +193,25 @@ async fn test_updating_connection_direction_on_new_session() {
     .await;
 
     // None -> Incoming
-    service.inject_session_established(
-        enr2.clone(),
-        ConnectionDirectionInstruction::IncomingIfNotExists,
-    );
+    service.inject_session_established(enr2.clone(), ConnectionUpdate::IncomingIfNotExists);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Incoming, status.direction);
 
     // Incoming -> Outgoing
-    service.inject_session_established(enr2.clone(), ConnectionDirectionInstruction::Outgoing);
+    service.inject_session_established(enr2.clone(), ConnectionUpdate::Outgoing);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Outgoing, status.direction);
 
     // Outgoing -> Outgoing (no changes as the outgoing connection exists)
-    service.inject_session_established(
-        enr2.clone(),
-        ConnectionDirectionInstruction::IncomingIfNotExists,
-    );
+    service.inject_session_established(enr2.clone(), ConnectionUpdate::IncomingIfNotExists);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Outgoing, status.direction);
 
     // Outgoing -> Incoming
-    service.inject_session_established(enr2, ConnectionDirectionInstruction::Incoming);
+    service.inject_session_established(enr2, ConnectionUpdate::Incoming);
     let status = service.kbuckets.read().iter_ref().next().unwrap().status;
     assert!(status.is_connected());
     assert_eq!(ConnectionDirection::Incoming, status.direction);


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

A connection direction can unexpectedly change from Outgoing to Incoming in the scenario shown in [this diagram](https://github.com/sigp/discv5/pull/184#issuecomment-1562032339). The diagram shows a specific case in PING/PONG. However, if we generalize this, when an `Outgoing` connection is established and the other node returns WHOAREYOU, the ConnectionDirection will change to `Incoming` at the time the new session is established. This could potentially cause some problems. e.g. IpVote doesn't work as IpVote ignores Incoming connections.

This PR makes the service to set only initial connection direction and not update it if a node already exists in the routing table.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

I have tested this PR with the PING/PONG simulation (https://github.com/sigp/discv5/pull/184), and confirmed that the Outgoing connection directions are kept.


```mermaid
sequenceDiagram
    participant Node1
    participant Node2

    rect rgb(10, 10, 10)
    Note left of Node1: <Node1's KBucket><br>[Node2] direction:Outgoing, state:Connected
    end
    Note over Node1,Node2: Session established

    rect rgb(10, 10, 10)
    Note left of Node1: Node1 changes its IP address<br> but doesn't update its ENR.
    end 
    Note over Node1: *** Change its IP address ***

    Node1 ->> Node2: PING
    Note over Node2: No session with the new IP exists
    Node2 ->> Node1: WHOAREYOU
    Note over Node1: Establish new session
    rect rgb(0, 255, 0)
    Note left of Node1: The Outgoing direction is kept<br> when establishing a new session here. 
    end
    rect rgb(0, 255, 0)
    Note left of Node1: <Node1's KBucket><br>[Node2] direction:***Outgoing***, state:Connected
    end
    Node1 ->> Node2: Auth message
    Note over Node2: Establish one-time session with Node1's new IP
    Note over Node2: Respond the PING using the one-time session
    Node2 ->> Node1: PONG
```

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
