### PR TITLE
Improve logs for ipv6 support

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -595,7 +595,7 @@ impl Handler {
             Some((node_address, request_call)) => {
                 // Verify that the src_addresses match
                 if node_address.socket_addr != src_address {
-                    trace!("Received a WHOAREYOU packet for a message with a non-expected source. Source {}, expected_source: {} message_nonce {}", src_address, node_address.socket_addr, hex::encode(request_nonce));
+                    debug!("Received a WHOAREYOU packet for a message with a non-expected source. Source {}, expected_source: {} message_nonce {}", src_address, node_address.socket_addr, hex::encode(request_nonce));
                     // Add the request back if src_address doesn't match
                     self.active_requests.insert(node_address, request_call);
                     return;

--- a/src/service.rs
+++ b/src/service.rs
@@ -1133,7 +1133,8 @@ impl Service {
                     return;
                 }
                 Err(NonContactable { enr }) => {
-                    error!("Query {} has a non contactable enr: {}", *query_id, enr);
+                    // This can happen quite often in ipv6 only nodes
+                    debug!("Query {} has a non contactable enr: {}", *query_id, enr);
                 }
             }
         } else {


### PR DESCRIPTION
Downgraded an error log which would occur quite frequently for ipv6 only nodes in an ipv4-dominated network. 

I also increased a log which was hiding messages being dropped because of invalid source addresses.