### PR TITLE
Update libp2p-core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get latest version of stable rust
         run: rustup update stable
-      - name: Install protobuf compiler for the libp2p-core dependency
-        uses: arduino/setup-protoc@v1
       - name: Lint code for quality and style with Clippy
         run: cargo clippy --workspace --tests --all-features -- -D warnings
   release-tests-ubuntu:
@@ -40,8 +38,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get latest version of stable rust
         run: rustup update stable
-      - name: Install protobuf compiler for the libp2p-core dependency
-        uses: arduino/setup-protoc@v1
       - name: Run tests in release
         run: cargo test --all --release --all-features
   check-rustdoc-links:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ exclude = [".gitignore", ".github/*"]
 enr = { version = "0.8.1", features = ["k256", "ed25519"] }
 tokio = { version = "1.15.0", features = ["net", "sync", "macros", "rt"] }
 libp2p-core = { version = "0.40.0", optional = true }
-libp2p-identity = { version = "0.2.1", optional = true }
-#multihash-codetable = { version = "0.1.0", optional = true }
+libp2p-identity = { version = "0.2.1", features = ["ed25519", "secp256k1"], optional = true }
 zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 futures = "0.3.19"
 uint = { version = "0.9.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ exclude = [".gitignore", ".github/*"]
 enr = { version = "0.8.1", features = ["k256", "ed25519"] }
 tokio = { version = "1.15.0", features = ["net", "sync", "macros", "rt"] }
 libp2p-core = { version = "0.40.0", optional = true }
+libp2p-identity = { version = "0.2.1", optional = true }
+#multihash-codetable = { version = "0.1.0", optional = true }
 zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 futures = "0.3.19"
 uint = { version = "0.9.1", default-features = false }
@@ -48,5 +50,5 @@ clap = { version = "3.1", features = ["derive"] }
 if-addrs = "0.10.1"
 
 [features]
-libp2p = ["libp2p-core"]
+libp2p = ["libp2p-core", "libp2p-identity"]
 serde = ["enr/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".gitignore", ".github/*"]
 [dependencies]
 enr = { version = "0.8.1", features = ["k256", "ed25519"] }
 tokio = { version = "1.15.0", features = ["net", "sync", "macros", "rt"] }
-libp2p-core = { version = "0.36.0", optional = true }
+libp2p-core = { version = "0.40.0", optional = true }
 zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 futures = "0.3.19"
 uint = { version = "0.9.1", default-features = false }

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -106,7 +106,7 @@ impl NodeContact {
         let peer_id = p2p.ok_or("The p2p protocol must be specified in the multiaddr")?;
 
         let public_key: CombinedPublicKey =
-            match PublicKey::from_protobuf_encoding(&peer_id.to_bytes()[2..])
+            match PublicKey::try_decode_protobuf(&peer_id.to_bytes()[2..])
                 .map_err(|_| "Invalid public key")?
             {
                 PublicKey::Secp256k1(pk) => {

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -4,7 +4,9 @@ use enr::{CombinedPublicKey, NodeId};
 use std::net::SocketAddr;
 
 #[cfg(feature = "libp2p")]
-use libp2p_core::{identity::PublicKey, multiaddr::Protocol, multihash, Multiaddr};
+use libp2p_core::{multiaddr::Protocol, multihash, Multiaddr};
+#[cfg(feature = "libp2p")]
+use libp2p_identity::PublicKey;
 
 /// This type relaxes the requirement of having an ENR to connect to a node, to allow for unsigned
 /// connection types, such as multiaddrs.


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

Update libp2p-core to the latest version so that we can remove the protoc dependency.

https://github.com/libp2p/rust-libp2p/blob/master/core/CHANGELOG.md


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

Notable changes of dependencies related this PR:

- libp2p_core
  - `identity` moved from `libp2p_core::identity` to `libp2p_identity` since [0.40.0](https://github.com/libp2p/rust-libp2p/blob/master/core/CHANGELOG.md#0400)
- multiaddr
  - `Protocol::P2p` contain a `PeerId` instead of a `Multihash` since [0.18.0](https://github.com/multiformats/rust-multiaddr/blob/master/CHANGELOG.md#0180)
- libp2p_identity
  - `PublicKey::from_protobuf_encoding` has been renamed to `PublicKey::try_decode_protobuf` in [0.1.2](https://github.com/libp2p/rust-libp2p/blob/master/identity/CHANGELOG.md#012)
  - `PublicKey::encode_uncompressed` has been renamed to `PublicKey::to_bytes_uncompressed` in [0.1.2](https://github.com/libp2p/rust-libp2p/blob/master/identity/CHANGELOG.md#012)
  - `PublicKey::encode` has been renamed to `PublicKey::to_bytes` in [0.1.2](https://github.com/libp2p/rust-libp2p/blob/master/identity/CHANGELOG.md#012)
  - `PublicKey` has been made opaque since [0.2.0](https://github.com/libp2p/rust-libp2p/blob/master/identity/CHANGELOG.md#020)

I have tested this change with the `request_enr` example:

```bash
$ cargo run --all-features --example request_enr /ip4/168.119.142.133/udp/9000/p2p/16Uiu2HAm6zDun1JBzHVcX7XDPxh3sPqkhfyN7dew4J5UNWAfDEdH
ENR Found:
Base64:enr:-L64QON1kt-4lAFXbqHRn6QLaNxgplXV658zfbKuOi2WNBXiOXeX7FulKi-9IXxUPnLioTlTMuTAlmIh0R-0TDX0U5qChiSHYXR0bmV0c4gAgAEAAAAAAIRldGgykGKJQe8DABAg__________-CaWSCdjSCaXCEqHeOhYlzZWNwMjU2azGhAqvHPwzUgfAmpEikOp1Vb9TU96LExblJ-cEP7yJ1ghCsiHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo
enr:-L64QON1kt-4lAFXbqHRn6QLaNxgplXV658zfbKuOi2WNBXiOXeX7FulKi-9IXxUPnLioTlTMuTAlmIh0R-0TDX0U5qChiSHYXR0bmV0c4gAgAEAAAAAAIRldGgykGKJQe8DABAg__________-CaWSCdjSCaXCEqHeOhYlzZWNwMjU2azGhAqvHPwzUgfAmpEikOp1Vb9TU96LExblJ-cEP7yJ1ghCsiHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo
```


## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
