### PR TITLE
Version bump to v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
-version = "0.3.0"
+version = "0.3.1"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "Apache-2.0"
 repository = "https://github.com/sigp/discv5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.8.1", features = ["k256", "ed25519"] }
+enr = { version = "0.9.0", features = ["k256", "ed25519"] }
 tokio = { version = "1.15.0", features = ["net", "sync", "macros", "rt"] }
 libp2p-core = { version = "0.40.0", optional = true }
 libp2p-identity = { version = "0.2.1", features = ["ed25519", "secp256k1"], optional = true }


### PR DESCRIPTION
This bumps the ENR version and resolves #201 

I think this can be minor version bump. Primarily bug fixes in this release. What do you think @divagant-martian ?