### PR TITLE
fix rpc decoding to reject extra data

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -12,7 +12,6 @@ impl From<RequestId> for Vec<u8> {
         id.0
     }
 }
-
 impl RequestId {
     /// Decodes the ID from a raw bytes.
     pub fn decode(data: Vec<u8>) -> Result<Self, DecoderError> {
@@ -133,10 +132,7 @@ impl Request {
                 let mut s = RlpStream::new();
                 s.begin_list(2);
                 s.append(&id.as_bytes());
-                s.begin_list(distances.len());
-                for distance in distances {
-                    s.append(&distance);
-                }
+                s.append_list(&distances);
                 buf.extend_from_slice(&s.out());
                 buf
             }
@@ -307,8 +303,9 @@ impl Message {
         }
 
         let msg_type = data[0];
+        let data = &data[1..];
 
-        let rlp = rlp::Rlp::new(&data[1..]);
+        let rlp = rlp::Rlp::new(data);
 
         let list_len = rlp.item_count().and_then(|size| {
             if size < 2 {
@@ -317,6 +314,12 @@ impl Message {
                 Ok(size)
             }
         })?;
+
+        // verify there is no extra data
+        let payload_info = rlp.payload_info()?;
+        if data.len() != payload_info.header_len + payload_info.value_len {
+            return Err(DecoderError::RlpInconsistentLengthAndData);
+        }
 
         let id = RequestId::decode(rlp.val_at::<Vec<u8>>(0)?)?;
 
@@ -745,5 +748,24 @@ mod tests {
         let decoded = Message::decode(&encoded).unwrap();
 
         assert_eq!(request, decoded);
+    }
+
+    #[test]
+    fn reject_extra_data() {
+        let data = [6, 194, 0, 75];
+        let msg = Message::decode(&data).unwrap();
+        assert_eq!(
+            msg,
+            Message::Response(Response {
+                id: RequestId(vec![0]),
+                body: ResponseBody::Talk { response: vec![75] }
+            })
+        );
+
+        let data2 = [6, 193, 0, 75, 252];
+        Message::decode(&data2).expect_err("should reject extra data");
+
+        let data3 = [6, 194, 0, 75, 252];
+        Message::decode(&data3).expect_err("should reject extra data");
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -12,6 +12,7 @@ impl From<RequestId> for Vec<u8> {
         id.0
     }
 }
+
 impl RequestId {
     /// Decodes the ID from a raw bytes.
     pub fn decode(data: Vec<u8>) -> Result<Self, DecoderError> {


### PR DESCRIPTION
## Description

addresses #207 
verify that received data does not contain extra bytes when doing rlp encoding.

## Notes & open questions

This is (I think) appropriate workaround to what I would consider either a bug or an api shortcoming in `rlp`

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [x] Tests if relevant
