### PR TITLE
Make node-type in kbuckets generic 

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -15,7 +15,7 @@
 use crate::{
     error::{Error, QueryError, RequestError},
     kbucket::{
-        self, AsNode, ConnectionDirection, ConnectionState, FailureReason, InsertResult,
+        self, node::NodeRecord, ConnectionDirection, ConnectionState, FailureReason, InsertResult,
         KBucketsTable, Node, NodeStatus, UpdateResult,
     },
     node_info::NodeContact,
@@ -79,7 +79,7 @@ pub enum Event {
 /// interacting with the underlying service.
 pub struct Discv5<
     P: ProtocolIdentity = DefaultProtocolId,
-    N: AsNode<NodeId, Enr> + Clone + Send + Sync + 'static = Node<NodeId, Enr>,
+    N: NodeRecord<NodeId, Enr> + Clone + Send + Sync + 'static = Node<NodeId, Enr>,
 > {
     config: Config,
     /// The channel to make requests from the main service.
@@ -101,7 +101,7 @@ pub struct Discv5<
 impl<P, N> Discv5<P, N>
 where
     P: ProtocolIdentity,
-    N: AsNode<NodeId, Enr> + Clone + Send + Sync + 'static,
+    N: NodeRecord<NodeId, Enr> + Clone + Send + Sync + 'static,
 {
     pub fn new(
         local_enr: Enr,
@@ -702,7 +702,7 @@ where
     }
 }
 
-impl<P: ProtocolIdentity, N: AsNode<NodeId, Enr> + Clone + Send + Sync> Drop for Discv5<P, N> {
+impl<P: ProtocolIdentity, N: NodeRecord<NodeId, Enr> + Clone + Send + Sync> Drop for Discv5<P, N> {
     fn drop(&mut self) {
         self.shutdown();
     }

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -89,7 +89,11 @@ impl NodeStatus {
     }
 }
 
-impl<TNode: AsNode<TNodeId, TVal>, TNodeId, TVal: Eq> PendingNode<TNode, TNodeId, TVal> {
+impl<TNode, TNodeId, TVal> PendingNode<TNode, TNodeId, TVal>
+where
+    TNode: NodeRecord<TNodeId, TVal>,
+    TVal: Eq,
+{
     pub fn status(&self) -> NodeStatus {
         *self.node.node_ref().status
     }
@@ -114,52 +118,6 @@ pub struct Node<TNodeId, TVal: Eq> {
     pub value: TVal,
     /// The status of the node.
     pub status: NodeStatus,
-}
-
-/// Returned by [AsNode::node_mut(&self)]
-pub struct AsNodeRef<'a, TNodeId, TVal> {
-    pub key: &'a Key<TNodeId>,
-    pub value: &'a TVal,
-    pub status: &'a NodeStatus,
-}
-
-/// Returned by [AsNode::node_ref(&self)].
-pub struct AsNodeRefMut<'a, TNodeId, TVal> {
-    pub key: &'a mut Key<TNodeId>,
-    pub value: &'a mut TVal,
-    pub status: &'a mut NodeStatus,
-}
-
-/// Common interface for types that are insertable into a k-bucket and
-/// hold information about a peer in the Kademlia DHT.
-pub trait AsNode<TNodeId, TVal: Eq> {
-    fn new(key: Key<TNodeId>, value: TVal, status: NodeStatus) -> Self;
-    fn node_ref(&self) -> AsNodeRef<'_, TNodeId, TVal>;
-    fn node_mut(&mut self) -> AsNodeRefMut<'_, TNodeId, TVal>;
-    fn take(self) -> Node<TNodeId, TVal>;
-}
-
-impl<TNodeId, TVal: Eq> AsNode<TNodeId, TVal> for Node<TNodeId, TVal> {
-    fn new(key: Key<TNodeId>, value: TVal, status: NodeStatus) -> Self {
-        Node { key, value, status }
-    }
-    fn node_ref(&self) -> AsNodeRef<'_, TNodeId, TVal> {
-        AsNodeRef {
-            key: &self.key,
-            value: &self.value,
-            status: &self.status,
-        }
-    }
-    fn node_mut(&mut self) -> AsNodeRefMut<'_, TNodeId, TVal> {
-        AsNodeRefMut {
-            key: &mut self.key,
-            value: &mut self.value,
-            status: &mut self.status,
-        }
-    }
-    fn take(self) -> Node<TNodeId, TVal> {
-        self
-    }
 }
 
 /// The position of a node in a `KBucket`, i.e. a non-negative integer
@@ -299,7 +257,7 @@ impl<TNode, TNodeId, TVal: Eq> AppliedPending<TNode, TNodeId, TVal> {
 
 impl<TNode, TNodeId, TVal> KBucket<TNode, TNodeId, TVal>
 where
-    TNode: AsNode<TNodeId, TVal>,
+    TNode: NodeRecord<TNodeId, TVal>,
     TNodeId: Clone,
     TVal: Eq,
 {

--- a/src/kbucket/entry.rs
+++ b/src/kbucket/entry.rs
@@ -26,8 +26,7 @@
 
 pub use super::{
     bucket::{
-        AppliedPending, AsNode, ConnectionState, InsertResult, Node, NodeStatus,
-        MAX_NODES_PER_BUCKET,
+        AppliedPending, ConnectionState, InsertResult, Node, NodeStatus, MAX_NODES_PER_BUCKET,
     },
     key::*,
     ConnectionDirection,
@@ -89,7 +88,7 @@ struct EntryRef<'a, TPeer, TPeerId, TVal: Eq> {
 
 impl<'a, TPeer, TPeerId, TVal> Entry<'a, TPeer, TPeerId, TVal>
 where
-    TPeer: AsNode<TPeerId, TVal>,
+    TPeer: NodeRecord<TPeerId, TVal>,
     TPeerId: Clone,
     TVal: Eq,
 {
@@ -116,7 +115,7 @@ pub struct PresentEntry<'a, TPeer, TPeerId, TVal: Eq>(EntryRef<'a, TPeer, TPeerI
 
 impl<'a, TPeer, TPeerId, TVal> PresentEntry<'a, TPeer, TPeerId, TVal>
 where
-    TPeer: AsNode<TPeerId, TVal>,
+    TPeer: NodeRecord<TPeerId, TVal>,
     TPeerId: Clone,
     TVal: Eq,
 {
@@ -176,7 +175,7 @@ pub struct PendingEntry<'a, TPeer, TPeerId, TVal: Eq>(EntryRef<'a, TPeer, TPeerI
 
 impl<'a, TPeer, TPeerId, TVal: Eq> PendingEntry<'a, TPeer, TPeerId, TVal>
 where
-    TPeer: AsNode<TPeerId, TVal>,
+    TPeer: NodeRecord<TPeerId, TVal>,
     TPeerId: Clone,
     TVal: Eq,
 {
@@ -211,7 +210,7 @@ pub struct AbsentEntry<'a, TPeer, TPeerId, TVal: Eq>(EntryRef<'a, TPeer, TPeerId
 
 impl<'a, TPeer, TPeerId, TVal> AbsentEntry<'a, TPeer, TPeerId, TVal>
 where
-    TPeer: AsNode<TPeerId, TVal>,
+    TPeer: NodeRecord<TPeerId, TVal>,
     TPeerId: Clone,
     TVal: Eq,
 {
@@ -223,6 +222,6 @@ where
     pub fn insert(self, value: TVal, status: NodeStatus) -> InsertResult<TPeerId> {
         self.0
             .bucket
-            .insert(AsNode::new(self.0.key.clone(), value, status))
+            .insert(NodeRecord::new(self.0.key.clone(), value, status))
     }
 }

--- a/src/kbucket/node.rs
+++ b/src/kbucket/node.rs
@@ -1,0 +1,58 @@
+use super::bucket::{Node, NodeStatus};
+use super::key::Key;
+
+/// Common interface for types that are insertable into a k-bucket and
+/// hold information about a peer in the Kademlia DHT.
+pub trait NodeRecord<TNodeId, TVal: Eq> {
+    fn new(key: Key<TNodeId>, value: TVal, status: NodeStatus) -> Self;
+    fn node_ref(&self) -> RecordRef<'_, TNodeId, TVal>;
+    fn node_mut(&mut self) -> RecordMut<'_, TNodeId, TVal>;
+    fn take(self) -> TakenRecord<TNodeId, TVal>;
+}
+
+/// Returned by [NodeRecord::node_mut(&self)]
+pub struct RecordRef<'a, TNodeId, TVal> {
+    pub key: &'a Key<TNodeId>,
+    pub value: &'a TVal,
+    pub status: &'a NodeStatus,
+}
+
+/// Returned by [NodeRecord::node_ref(&self)].
+pub struct RecordMut<'a, TNodeId, TVal> {
+    pub key: &'a mut Key<TNodeId>,
+    pub value: &'a mut TVal,
+    pub status: &'a mut NodeStatus,
+}
+
+pub struct TakenRecord<TNodeId, TVal> {
+    pub key: Key<TNodeId>,
+    pub value: TVal,
+    pub status: NodeStatus,
+}
+
+impl<TNodeId, TVal: Eq> NodeRecord<TNodeId, TVal> for Node<TNodeId, TVal> {
+    fn new(key: Key<TNodeId>, value: TVal, status: NodeStatus) -> Self {
+        Node { key, value, status }
+    }
+    fn node_ref(&self) -> RecordRef<'_, TNodeId, TVal> {
+        RecordRef {
+            key: &self.key,
+            value: &self.value,
+            status: &self.status,
+        }
+    }
+    fn node_mut(&mut self) -> RecordMut<'_, TNodeId, TVal> {
+        RecordMut {
+            key: &mut self.key,
+            value: &mut self.value,
+            status: &mut self.status,
+        }
+    }
+    fn take(self) -> TakenRecord<TNodeId, TVal> {
+        TakenRecord {
+            key: self.key,
+            value: self.value,
+            status: self.status,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub use config::{Config, ConfigBuilder};
 pub use error::{Error, QueryError, RequestError, ResponseError};
 pub use executor::{Executor, TokioExecutor};
 pub use ipmode::IpMode;
+pub use kbucket::node::{NodeRecord, RecordMut, RecordRef, TakenRecord};
 pub use kbucket::{ConnectionDirection, ConnectionState, Key};
 pub use packet::{DefaultProtocolId, ProtocolIdentity};
 pub use permit_ban::PermitBanList;

--- a/src/service.rs
+++ b/src/service.rs
@@ -21,7 +21,7 @@ use crate::{
     error::{RequestError, ResponseError},
     handler::{Handler, HandlerIn, HandlerOut},
     kbucket::{
-        self, AsNode, ConnectionDirection, ConnectionState, FailureReason, InsertResult,
+        self, node::NodeRecord, ConnectionDirection, ConnectionState, FailureReason, InsertResult,
         KBucketsTable, Node, NodeStatus, UpdateResult, MAX_NODES_PER_BUCKET,
     },
     node_info::{NodeAddress, NodeContact, NonContactable},
@@ -269,7 +269,7 @@ impl Default for NodesResponse {
 
 impl<N> Service<N>
 where
-    N: AsNode<NodeId, Enr> + Send + Sync + 'static,
+    N: NodeRecord<NodeId, Enr> + Send + Sync + 'static,
 {
     /// Builds the `Service` main struct.
     ///


### PR DESCRIPTION
## Description
Support generic node-types in k-buckets.
* Introduce a ~`AsNode`~ `NodeRecord` trait.
* Modify `KbucketsTable` & `DiscV5` struct-defs and methods to be generic over types that implement this trait.

## Notes & open questions
This is a draft PR to set in motion the ideas proposed in #193 . The complete discussion can be found [here](https://github.com/ethereum/trin/issues/750).

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
