### PR TITLE
expected_responses remains after challenge has been completed

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -793,6 +793,8 @@ impl Handler {
                 enr_record,
             ) {
                 Ok((mut session, enr)) => {
+                    // Remove the expected response for the challenge.
+                    self.remove_expected_response(node_address.socket_addr);
                     // Receiving an AuthResponse must give us an up-to-date view of the node ENR.
                     // Verify the ENR is valid
                     if self.verify_enr(&enr, &node_address) {


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

```mermaid
sequenceDiagram
    participant Node1
    participant Node2
    Node1 ->> Node2: Random packet
    Note over Node2: send_challenge()<br> expected_response: 1

    Node2 -->> Node1: WHOAREYOU
    Node1 ->> Node2: Handshake Message(FINDNODE)
    Node2 -->> Node1: NODES

    rect rgb(100, 0, 0)
    Note over Node2: expected_response remains 1
    end
```

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

I've enhanced `multiple_messages` test: 
  - replaced `Handler::spawn()` with `build_handler()` and `Handler::start()`
  - added assertions to test handler's states

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
