### PR TITLE
Expose underlying ENR representation externally

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -301,6 +301,13 @@ impl<P: ProtocolIdentity> Discv5<P> {
         self.local_enr.read().clone()
     }
 
+    /// Identical to `Discv5::local_enr` except that this exposes the `Arc` itself.
+    ///
+    /// This is useful for synchronising views of the local ENR outside of `Discv5`.
+    pub fn external_enr(&self) -> Arc<RwLock<Enr>> {
+        self.local_enr.clone()
+    }
+
     /// Returns the routing table of the discv5 service
     pub fn kbuckets(&self) -> KBucketsTable<NodeId, Enr> {
         self.kbuckets.read().clone()


### PR DESCRIPTION
## Description

Closes #211.

## Notes & open questions

### Proposed Changes

 - Add a method to `Discv5`, `external_enr`, which returns an `Arc<RwLock<Enr>>`

## Change checklist

- [x] Self-review
- [x] ~~Documentation updates if relevant~~
- [x] ~~Tests if relevant~~
