### PR TITLE
Expand metrics for errors and warnings

### DIFF
--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -1,3 +1,5 @@
+use crate::metrics::{NO_MATCHING_NONCE, NO_MATCHING_REQ_CALL};
+
 use super::*;
 use delay_map::HashMapDelay;
 use more_asserts::debug_unreachable;
@@ -39,6 +41,7 @@ impl ActiveRequests {
                 None => {
                     debug_unreachable!("A matching request call doesn't exist");
                     error!("A matching request call doesn't exist");
+                    let _ = &METRICS.error(NO_MATCHING_REQ_CALL);
                     None
                 }
             },
@@ -58,6 +61,7 @@ impl ActiveRequests {
                     None => {
                         debug_unreachable!("A matching nonce mapping doesn't exist");
                         error!("A matching nonce mapping doesn't exist");
+                        let _ = &METRICS.error(NO_MATCHING_NONCE);
                         None
                     }
                 }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -30,6 +30,7 @@ use crate::{
     config::Config,
     discv5::PERMIT_BAN_LIST,
     error::{Error, RequestError},
+    metrics::SESS_GENERATE_FAIL,
     packet::{ChallengeData, IdNonce, MessageNonce, Packet, PacketKind, ProtocolIdentity},
     rpc::{Message, Request, RequestBody, RequestId, Response, ResponseBody},
     socket,
@@ -668,6 +669,7 @@ impl Handler {
             Ok(v) => v,
             Err(e) => {
                 error!("Could not generate a session. Error: {:?}", e);
+                let _ = &METRICS.error(SESS_GENERATE_FAIL);
                 self.fail_request(request_call, RequestError::InvalidRemotePacket, true)
                     .await;
                 return;

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -471,7 +471,7 @@ impl Handler {
             trace!("Request queued for node: {}", node_address);
             self.pending_requests
                 .entry(node_address)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(PendingRequest {
                     contact,
                     request_id,

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -30,6 +30,8 @@
 
 #![allow(dead_code)]
 
+use crate::metrics::{KBUCKET_NOT_FULL, METRICS};
+
 use super::*;
 use tracing::{debug, error};
 
@@ -354,6 +356,7 @@ where
                         }
                         InsertResult::Full => unreachable!("Bucket cannot be full"),
                         InsertResult::Pending { .. } | InsertResult::NodeExists => {
+                            let _ = &METRICS.error(KBUCKET_NOT_FULL);
                             error!("Bucket is not full or double node")
                         }
                         InsertResult::FailedFilter => debug!("Pending node failed filter"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //!    });
 //! ```
 
-mod config;
+pub mod config;
 mod discv5;
 mod error;
 mod executor;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,7 +34,7 @@ impl ErrorMetrics {
             .store(current_total_errors.saturating_add(1), Ordering::Relaxed);
     }
 
-    pub fn inc_individual_error(&mut self, error: String) {
+    pub fn inc_individual_error(&self, error: String) {
         if let Some(curr_count) = self.errors.read().get(error.as_str()) {
             let curr_count = curr_count.load(Ordering::Relaxed);
             self.errors
@@ -98,7 +98,7 @@ impl InternalMetrics {
             .store(current_bytes_sent.saturating_add(bytes), Ordering::Relaxed);
     }
 
-    pub fn error(&mut self, error: String) {
+    pub fn error(&self, error: String) {
         self.error_metrics.inc_total_errors();
         self.error_metrics.inc_individual_error(error);
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,167 +3,15 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use parking_lot::RwLock;
-
 lazy_static! {
     pub static ref METRICS: InternalMetrics = InternalMetrics::default();
 }
 
-/* WARNINGS */
-
-/// An attempt to send an empty response to a TALK message failed
-pub const SEND_EMPTY_TALK_RESP_FAIL: &str = "send_empty_talk_response_failed";
-
-/// An attempt to send a WHOAREYOU message failed
-pub const SEND_WHOAREYOU_FAIL: &str = "send_whoareyou_fail";
-
-/// An inbound RPC request timed out
-pub const RPC_REQ_TIMEOUT: &str = "rpc_req_timeout";
-
-/// An inbound RPC request errored
-pub const RPC_REQ_FAIL: &str = "rpc_req_fail";
-
-/// The results of a RPC query did not contain an ENR
-pub const QUERY_RES_ENR_MISSING: &str = "query_res_enr_missing";
-
-/// The callback used for servicing a RPC query was dropped
-pub const QUERY_CALLBACK_DROPPED: &str = "query_callback_dropped";
-
-/// No peers were close enough to satisfy the request
-pub const NO_KNOWN_CLOSEST_PEERS: &str = "no_known_closest_peers";
-
-/// The callback servicing a query failed for an unknown reason
-pub const CALLBACK_FAILED: &str = "callback_failed";
-
-/// A `NodesResponse` was received which contained too many nodes; the remainders will be ignored
-pub const TRUNCATING_NODES: &str = "truncating_nodes";
-
-/// Received the incorrect message type as a response to a request
-pub const INCORRECT_RESP_TYPE: &str = "incorrect_resp_type";
-
-/// Failed to send a response to a request
-pub const SEND_RESP_FAIL: &str = "send_resp_fail";
-
-/// A peer is advertising multiple ENRs
-pub const PEER_MULTIPLE_ENRS: &str = "peer_multiple_enrs";
-
-/// The ID of a response message didn't match the expected ID for the request message
-pub const RPC_RESP_MISMATCH: &str = "rpc_resp_mismatch";
-
-/// Failed to write to a required socket
-pub const SOCK_UPDATE_FAIL: &str = "sock_update_fail";
-
-/// Failed to respond to a FINDNODES message
-pub const SEND_FINDNODES_RESP_FAIL: &str = "send_findnodes_resp_fail";
-
-/// Responding to a NODES message failed, but was able to be partially processed (hence this is a warning)
-pub const RPC_NODE_RESP_FAIL: &str = "rpc_node_resp_fail";
-
-/// Failed to transition a node to the disconnected state
-pub const NODE_UPDATE_DISCONNECT_FAIL: &str = "node_update_disconnect_fail";
-
-/// A peer forwarded us an invalid ENR
-pub const PEER_SENT_BAD_ENR: &str = "peer_sent_bad_enr";
-
-/// An attempt to send an empty response to a FINDNODES message failed
-pub const SEND_EMPTY_FINDNODES_RESP_FAIL: &str = "send_empty_findnodes_resp_fail";
-
-/* ERRORS */
-
-/// No request handler was found for this request
-pub const NO_MATCHING_REQ_CALL: &str = "no_matching_req_call";
-
-/// No matching nonce was found
-pub const NO_MATCHING_NONCE: &str = "no_matching_nonce";
-
-/// Failed to generate a session
-pub const SESS_GENERATE_FAIL: &str = "sess_generate_fail";
-
-/// Insertion into a kbucket did not succeed but the kbucket is not full
-pub const KBUCKET_NOT_FULL: &str = "kbucket_not_full";
-
-/// An attempt to send a packet to a peer failed due to a socket mismatch
-pub const SOCK_MISMATCH_ON_SEND: &str = "sock_mismatch_on_send";
-
-/// Failed to return from an event channel
-pub const EV_CHAN_RET_FAIL: &str = "ev_chan_ret_fail";
-
-/// An ENR advertising unreachable IP addresses was encountered (this violates the ENR invariant)
-pub const UNREACHABLE_ENR: &str = "unreachable_enr";
-
-/// A response to a message was received that was not expected
-pub const RECV_RESP_UNEXPECTED: &str = "recv_resp_unexpected";
-
-/// Represents metrics pertaining to errors and warnings that occur throughout
-/// the course of server operation
-#[derive(Debug, Default)]
-pub struct ErrorMetrics {
-    /// Total number of errors that have occurred
-    pub total_errors: AtomicUsize,
-    /// Total number of warnings that have occurred
-    pub total_warnings: AtomicUsize,
-    /// Individual errors that have occurred, with their associated counts
-    pub errors: RwLock<HashMap<&'static str, AtomicUsize>>,
-    /// Individual warnings that have occurred, with their associated counts
-    pub warnings: RwLock<HashMap<&'static str, AtomicUsize>>,
-}
-
-impl ErrorMetrics {
-    pub fn inc_total_errors(&self) {
-        let current_total_errors = self.total_errors.load(Ordering::Relaxed);
-        self.total_errors
-            .store(current_total_errors.saturating_add(1), Ordering::Relaxed);
-    }
-
-    pub fn inc_total_warnings(&self) {
-        let current_total_errors = self.total_errors.load(Ordering::Relaxed);
-        self.total_errors
-            .store(current_total_errors.saturating_add(1), Ordering::Relaxed);
-    }
-
-    pub fn inc_individual_error(&self, error: &'static str) {
-        let lock = self.errors.read();
-
-        let curr_count: Option<usize> = lock.get(error).map(|t| t.load(Ordering::Relaxed));
-
-        drop(lock);
-
-        if let Some(curr_count) = curr_count {
-            self.errors
-                .write()
-                .get_mut(error)
-                .unwrap()
-                .store(curr_count.saturating_add(1), Ordering::Relaxed);
-        } else {
-            self.errors.write().insert(error, 0.into());
-        }
-    }
-
-    pub fn inc_individual_warning(&self, warning: &'static str) {
-        let lock = self.warnings.read();
-
-        let curr_count: Option<usize> = lock.get(warning).map(|t| t.load(Ordering::Relaxed));
-
-        drop(lock);
-
-        if let Some(curr_count) = curr_count {
-            self.warnings
-                .write()
-                .get_mut(warning)
-                .unwrap()
-                .store(curr_count.saturating_add(1), Ordering::Relaxed);
-        } else {
-            self.warnings.write().insert(warning, 0.into());
-        }
-    }
-
-    pub fn as_raw(&self) -> HashMap<&'static str, usize> {
-        self.errors
-            .read()
-            .iter()
-            .map(|(k, v)| (*k, v.load(Ordering::Relaxed)))
-            .collect()
-    }
+/// Represents the severity of a failure within Discv5
+pub enum FailureSeverity {
+    Critical,
+    Error,
+    Warning,
 }
 
 /// A collection of metrics used throughout the server.
@@ -178,8 +26,12 @@ pub struct InternalMetrics {
     pub bytes_sent: AtomicUsize,
     /// The number of bytes received.
     pub bytes_recv: AtomicUsize,
-    /// Information about errors
-    pub error_metrics: ErrorMetrics,
+    /// Total number of critical failures that have occurred
+    pub total_criticals: AtomicUsize,
+    /// Total number of errors that have occurred
+    pub total_errors: AtomicUsize,
+    /// Total number of warnings that have occurred
+    pub total_warnings: AtomicUsize,
 }
 
 impl Default for InternalMetrics {
@@ -190,7 +42,9 @@ impl Default for InternalMetrics {
             unsolicited_requests_per_window: AtomicUsize::new(0),
             bytes_sent: AtomicUsize::new(0),
             bytes_recv: AtomicUsize::new(0),
-            error_metrics: ErrorMetrics::default(),
+            total_criticals: AtomicUsize::default(),
+            total_errors: AtomicUsize::default(),
+            total_warnings: AtomicUsize::default(),
         }
     }
 }
@@ -208,14 +62,27 @@ impl InternalMetrics {
             .store(current_bytes_sent.saturating_add(bytes), Ordering::Relaxed);
     }
 
-    pub fn error(&self, error: &'static str) {
-        self.error_metrics.inc_total_errors();
-        self.error_metrics.inc_individual_error(error);
+    /// Logs a failure with the discovery service
+    ///
+    /// # Parameters #
+    ///
+    ///  - `msg`, the severity of the failure
+    ///
+    /// This (atomically) increments the appropriate internal counter for the failure type
+    pub fn log_failure(&self, failure: FailureSeverity) {
+        match failure {
+            FailureSeverity::Critical => self.increment_field(&self.total_criticals),
+            FailureSeverity::Error => self.increment_field(&self.total_errors),
+            FailureSeverity::Warning => self.increment_field(&self.total_warnings),
+        }
     }
 
-    pub fn warning(&self, warning: &'static str) {
-        self.error_metrics.inc_total_warnings();
-        self.error_metrics.inc_individual_warning(warning);
+    /// Increments the `AtomicUsize` at the end of the provided reference
+    ///
+    /// Uses the `Relaxed` memory ordering to do so
+    fn increment_field(&self, field: &AtomicUsize) {
+        let curr_val = field.load(Ordering::Relaxed);
+        field.store(curr_val.saturating_add(1), Ordering::Relaxed);
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,6 +4,16 @@ lazy_static! {
     pub static ref METRICS: InternalMetrics = InternalMetrics::default();
 }
 
+/// Represents metrics pertaining to errors and warnings that occur throughout
+/// the course of server operation
+#[derive(Default)]
+pub struct ErrorMetrics {
+    /// Total number of errors that have occurred
+    pub total_errors: usize,
+    /// Total number of warnings that have occurred
+    pub total_warnings: usize,
+}
+
 /// A collection of metrics used throughout the server.
 pub struct InternalMetrics {
     /// The number of active UDP sessions that are currently established.
@@ -16,6 +26,8 @@ pub struct InternalMetrics {
     pub bytes_sent: AtomicUsize,
     /// The number of bytes received.
     pub bytes_recv: AtomicUsize,
+    /// Information about errors
+    pub error_metrics: ErrorMetrics,
 }
 
 impl Default for InternalMetrics {
@@ -26,6 +38,7 @@ impl Default for InternalMetrics {
             unsolicited_requests_per_window: AtomicUsize::new(0),
             bytes_sent: AtomicUsize::new(0),
             bytes_recv: AtomicUsize::new(0),
+            error_metrics: ErrorMetrics::default(),
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,33 +9,89 @@ lazy_static! {
     pub static ref METRICS: InternalMetrics = InternalMetrics::default();
 }
 
+/* WARNINGS */
+
+/// An attempt to send an empty response to a TALK message failed
 pub const SEND_EMPTY_TALK_RESP_FAIL: &str = "send_empty_talk_response_failed";
+
+/// An attempt to send a WHOAREYOU message failed
 pub const SEND_WHOAREYOU_FAIL: &str = "send_whoareyou_fail";
+
+/// An inbound RPC request timed out
 pub const RPC_REQ_TIMEOUT: &str = "rpc_req_timeout";
+
+/// An inbound RPC request errored
 pub const RPC_REQ_FAIL: &str = "rpc_req_fail";
+
+/// The results of a RPC query did not contain an ENR
 pub const QUERY_RES_ENR_MISSING: &str = "query_res_enr_missing";
+
+/// The callback used for servicing a RPC query was dropped
 pub const QUERY_CALLBACK_DROPPED: &str = "query_callback_dropped";
+
+/// No peers were close enough to satisfy the request
 pub const NO_KNOWN_CLOSEST_PEERS: &str = "no_known_closest_peers";
+
+/// The callback servicing a query failed for an unknown reason
 pub const CALLBACK_FAILED: &str = "callback_failed";
+
+/// A `NodesResponse` was received which contained too many nodes; the remainders will be ignored
 pub const TRUNCATING_NODES: &str = "truncating_nodes";
+
+/// Received the incorrect message type as a response to a request
 pub const INCORRECT_RESP_TYPE: &str = "incorrect_resp_type";
+
+/// Failed to send a response to a request
 pub const SEND_RESP_FAIL: &str = "send_resp_fail";
+
+/// A peer is advertising multiple ENRs
 pub const PEER_MULTIPLE_ENRS: &str = "peer_multiple_enrs";
+
+/// The ID of a response message didn't match the expected ID for the request message
 pub const RPC_RESP_MISMATCH: &str = "rpc_resp_mismatch";
+
+/// Failed to write to a required socket
 pub const SOCK_UPDATE_FAIL: &str = "sock_update_fail";
+
+/// Failed to respond to a FINDNODES message
 pub const SEND_FINDNODES_RESP_FAIL: &str = "send_findnodes_resp_fail";
+
+/// Responding to a NODES message failed, but was able to be partially processed (hence this is a warning)
 pub const RPC_NODE_RESP_FAIL: &str = "rpc_node_resp_fail";
+
+/// Failed to transition a node to the disconnected state
 pub const NODE_UPDATE_DISCONNECT_FAIL: &str = "node_update_disconnect_fail";
+
+/// A peer forwarded us an invalid ENR
 pub const PEER_SENT_BAD_ENR: &str = "peer_sent_bad_enr";
+
+/// An attempt to send an empty response to a FINDNODES message failed
 pub const SEND_EMPTY_FINDNODES_RESP_FAIL: &str = "send_empty_findnodes_resp_fail";
 
+/* ERRORS */
+
+/// No request handler was found for this request
 pub const NO_MATCHING_REQ_CALL: &str = "no_matching_req_call";
+
+/// No matching nonce was found
 pub const NO_MATCHING_NONCE: &str = "no_matching_nonce";
+
+/// Failed to generate a session
 pub const SESS_GENERATE_FAIL: &str = "sess_generate_fail";
+
+/// Insertion into a kbucket did not succeed but the kbucket is not full
 pub const KBUCKET_NOT_FULL: &str = "kbucket_not_full";
+
+/// An attempt to send a packet to a peer failed due to a socket mismatch
 pub const SOCK_MISMATCH_ON_SEND: &str = "sock_mismatch_on_send";
+
+/// Failed to return from an event channel
 pub const EV_CHAN_RET_FAIL: &str = "ev_chan_ret_fail";
+
+/// An ENR advertising unreachable IP addresses was encountered (this violates the ENR invariant)
 pub const UNREACHABLE_ENR: &str = "unreachable_enr";
+
+/// A response to a message was received that was not expected
 pub const RECV_RESP_UNEXPECTED: &str = "recv_resp_unexpected";
 
 /// Represents metrics pertaining to errors and warnings that occur throughout

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,6 +9,26 @@ lazy_static! {
     pub static ref METRICS: InternalMetrics = InternalMetrics::default();
 }
 
+pub const SEND_EMPTY_TALK_RESP_FAIL: &str = "send_empty_talk_response_failed";
+pub const SEND_WHOAREYOU_FAIL: &str = "send_whoareyou_fail";
+pub const RPC_REQ_TIMEOUT: &str = "rpc_req_timeout";
+pub const RPC_REQ_FAIL: &str = "rpc_req_fail";
+pub const QUERY_RES_ENR_MISSING: &str = "query_res_enr_missing";
+pub const QUERY_CALLBACK_DROPPED: &str = "query_callback_dropped";
+pub const NO_KNOWN_CLOSEST_PEERS: &str = "no_known_closest_peers";
+pub const CALLBACK_FAILED: &str = "callback_failed";
+pub const TRUNCATING_NODES: &str = "truncating_nodes";
+pub const INCORRECT_RESP_TYPE: &str = "incorrect_resp_type";
+pub const SEND_RESP_FAIL: &str = "send_resp_fail";
+pub const PEER_MULTIPLE_ENRS: &str = "peer_multiple_enrs";
+pub const RPC_RESP_MISMATCH: &str = "rpc_resp_mismatch";
+pub const SOCK_UPDATE_FAIL: &str = "sock_update_fail";
+pub const SEND_FINDNODES_RESP_FAIL: &str = "send_findnodes_resp_fail";
+pub const RPC_NODE_RESP_FAIL: &str = "rpc_node_resp_fail";
+pub const NODE_UPDATE_DISCONNECT_FAIL: &str = "node_update_disconnect_fail";
+pub const PEER_SENT_BAD_ENR: &str = "peer_sent_bad_enr";
+pub const SEND_EMPTY_FINDNODES_RESP_FAIL: &str = "send_empty_findnodes_resp_fail";
+
 /// Represents metrics pertaining to errors and warnings that occur throughout
 /// the course of server operation
 #[derive(Debug, Default)]
@@ -51,7 +71,7 @@ impl ErrorMetrics {
         self.errors
             .read()
             .iter()
-            .map(|(k, v)| (k.clone(), v.load(Ordering::Relaxed)))
+            .map(|(k, v)| (*k, v.load(Ordering::Relaxed)))
             .collect()
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -57,11 +57,7 @@ impl ErrorMetrics {
     pub fn inc_individual_error(&self, error: &'static str) {
         let lock = self.errors.read();
 
-        let curr_count: Option<usize> = if let Some(t) = lock.get(error) {
-            Some(t.load(Ordering::Relaxed))
-        } else {
-            None
-        };
+        let curr_count: Option<usize> = lock.get(error).map(|t| t.load(Ordering::Relaxed));
 
         drop(lock);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,9 +9,23 @@ lazy_static! {
 #[derive(Default)]
 pub struct ErrorMetrics {
     /// Total number of errors that have occurred
-    pub total_errors: usize,
+    pub total_errors: AtomicUsize,
     /// Total number of warnings that have occurred
-    pub total_warnings: usize,
+    pub total_warnings: AtomicUsize,
+}
+
+impl ErrorMetrics {
+    pub fn inc_total_errors(&self) {
+        let current_total_errors = self.total_errors.load(Ordering::Relaxed);
+        self.total_errors
+            .store(current_total_errors.saturating_add(1), Ordering::Relaxed);
+    }
+
+    pub fn inc_total_warnings(&self) {
+        let current_total_errors = self.total_errors.load(Ordering::Relaxed);
+        self.total_errors
+            .store(current_total_errors.saturating_add(1), Ordering::Relaxed);
+    }
 }
 
 /// A collection of metrics used throughout the server.
@@ -54,6 +68,14 @@ impl InternalMetrics {
         let current_bytes_sent = self.bytes_sent.load(Ordering::Relaxed);
         self.bytes_sent
             .store(current_bytes_sent.saturating_add(bytes), Ordering::Relaxed);
+    }
+
+    pub fn error(&self) {
+        self.error_metrics.inc_total_errors()
+    }
+
+    pub fn warning(&self) {
+        self.error_metrics.inc_total_errors()
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -29,6 +29,15 @@ pub const NODE_UPDATE_DISCONNECT_FAIL: &str = "node_update_disconnect_fail";
 pub const PEER_SENT_BAD_ENR: &str = "peer_sent_bad_enr";
 pub const SEND_EMPTY_FINDNODES_RESP_FAIL: &str = "send_empty_findnodes_resp_fail";
 
+pub const NO_MATCHING_REQ_CALL: &str = "no_matching_req_call";
+pub const NO_MATCHING_NONCE: &str = "no_matching_nonce";
+pub const SESS_GENERATE_FAIL: &str = "sess_generate_fail";
+pub const KBUCKET_NOT_FULL: &str = "kbucket_not_full";
+pub const SOCK_MISMATCH_ON_SEND: &str = "sock_mismatch_on_send";
+pub const EV_CHAN_RET_FAIL: &str = "ev_chan_ret_fail";
+pub const UNREACHABLE_ENR: &str = "unreachable_enr";
+pub const RECV_RESP_UNEXPECTED: &str = "recv_resp_unexpected";
+
 /// Represents metrics pertaining to errors and warnings that occur throughout
 /// the course of server operation
 #[derive(Debug, Default)]

--- a/src/socket/send.rs
+++ b/src/socket/send.rs
@@ -1,5 +1,10 @@
 //! This is a standalone task that encodes and sends Discv5 UDP packets
-use crate::{metrics::METRICS, node_info::NodeAddress, packet::*, Executor};
+use crate::{
+    metrics::{METRICS, SOCK_MISMATCH_ON_SEND},
+    node_info::NodeAddress,
+    packet::*,
+    Executor,
+};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{
     net::UdpSocket,
@@ -74,6 +79,7 @@ impl SendHandler {
                                 trace!("Could not send packet to {addr} . Error: {e}");
                             },
                             Error::SocketMismatch => {
+                                let _ = &METRICS.error(SOCK_MISMATCH_ON_SEND);
                                 error!("Socket mismatch attempting to send a packet to {addr}.")
                             }
                         }


### PR DESCRIPTION
## Description

Closes #213.

## Notes & open questions

This PR expands the metrics collected by the Discv5 service to include errors and warnings that occur throughout the operation of the service. This is achieved by the introduction of a new type, `ErrorMetrics`, which stores four elements:

 - Total number of errors
 - Total number of warnings
 - Mapping of specific errors to their associated counts
 - Mapping of specific warnings to their associated counts

A few technical notes:

 - Cumulative counts are stored *in addition to* individual counts to avoid having to load each `AtomicUsize` in a manner such as `self.errors.read().values().map(|at| at.load(Ordering::Relaxed).sum()`. The additional memory overhead is considered negligible as is the added locking overhead
 - Errors and warnings are uniquely identified solely by strings. Presently, these are provided by named constants within the `metrics` module. Assigning unique numeric identifiers was considered but would add complexity with little benefit (these will eventually be turned back into *some* string representation when these hit Grafana/Prometheus, anyway).

Notes for reviewers:

 - I'm very open to the names of these error/warning strings changing to be more descriptive/clear, but once again, they are still largely arbitrary
 - With regards to testing, these changes are particularly challenging to test as they exclusively target failure modes of the discovery service. Manual testing, by executing [the various examples](https://github.com/sigp/discv5/tree/master/examples) in the repository, was performed in order to check for basic defects (such as panics, deadlocks, fatal errors, etc.). Additionally, I plumbed this branch into Lighthouse mainline and tested by polling the metrics endpoint (this won't yield any of the metrics in this PR as they need to be added to LH separately, but this nonetheless validates that the discovery service is functioning correctly even with the changes in this PR on a live BN).

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant (by way of doc comments)
- [x] ~~Tests if relevant~~
