### PR TITLE
Changing port of ReponseBody::Pong to NonZeroU16

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -471,7 +471,7 @@ impl Handler {
             trace!("Request queued for node: {}", node_address);
             self.pending_requests
                 .entry(node_address)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(PendingRequest {
                     contact,
                     request_id,

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -7,7 +7,10 @@ use crate::{
     rpc::{Request, Response},
     ConfigBuilder, IpMode,
 };
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::{
+    convert::TryInto,
+    net::{Ipv4Addr, Ipv6Addr},
+};
 
 use crate::{
     handler::{session::build_dummy_session, HandlerOut::RequestFailed},
@@ -258,7 +261,7 @@ async fn multiple_messages() {
         body: ResponseBody::Pong {
             enr_seq: 1,
             ip: ip.into(),
-            port: sender_port,
+            port: sender_port.try_into().unwrap(),
         },
     };
 

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -69,6 +69,17 @@ impl IpMode {
     }
 }
 
+/// Copied from the standard library. See <https://github.com/rust-lang/rust/issues/27709>
+/// The current code is behind the `ip` feature.
+pub const fn to_ipv4_mapped(ip: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
+    match ip.octets() {
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => {
+            Some(std::net::Ipv4Addr::new(a, b, c, d))
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,16 +239,5 @@ mod tests {
             .ip_mode(Ip6)
             .expect_ip6(Ipv6Addr::LOCALHOST)
             .test();
-    }
-}
-
-/// Copied from the standard library. See <https://github.com/rust-lang/rust/issues/27709>
-/// The current code is behind the `ip` feature.
-pub const fn to_ipv4_mapped(ip: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
-    match ip.octets() {
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d] => {
-            Some(std::net::Ipv4Addr::new(a, b, c, d))
-        }
-        _ => None,
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -539,7 +539,11 @@ mod tests {
         let port = 5000;
         let message = Message::Response(Response {
             id,
-            body: ResponseBody::Pong { enr_seq, ip, port },
+            body: ResponseBody::Pong {
+                enr_seq,
+                ip,
+                port: port.try_into().unwrap(),
+            },
         });
 
         // expected hex output
@@ -656,7 +660,7 @@ mod tests {
             body: ResponseBody::Pong {
                 enr_seq: 15,
                 ip: "127.0.0.1".parse().unwrap(),
-                port: 80,
+                port: 80.try_into().unwrap(),
             },
         });
 
@@ -674,7 +678,7 @@ mod tests {
             body: ResponseBody::Pong {
                 enr_seq: 15,
                 ip: IpAddr::V6(Ipv4Addr::new(192, 0, 2, 1).to_ipv6_mapped()),
-                port: 80,
+                port: 80.try_into().unwrap(),
             },
         });
 
@@ -685,7 +689,7 @@ mod tests {
             body: ResponseBody::Pong {
                 enr_seq: 15,
                 ip: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
-                port: 80,
+                port: 80.try_into().unwrap(),
             },
         });
 
@@ -700,7 +704,7 @@ mod tests {
             body: ResponseBody::Pong {
                 enr_seq: 15,
                 ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
-                port: 80,
+                port: 80.try_into().unwrap(),
             },
         });
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -40,6 +40,7 @@ use parking_lot::RwLock;
 use rpc::*;
 use std::{
     collections::HashMap,
+    convert::TryInto,
     net::{IpAddr, SocketAddr},
     sync::Arc,
     task::Poll,
@@ -606,20 +607,24 @@ impl Service {
 
                 // build the PONG response
                 let src = node_address.socket_addr;
-                let response = Response {
-                    id,
-                    body: ResponseBody::Pong {
-                        enr_seq: self.local_enr.read().seq(),
-                        ip: src.ip(),
-                        port: src.port(),
-                    },
-                };
-                debug!("Sending PONG response to {}", node_address);
-                if let Err(e) = self
-                    .handler_send
-                    .send(HandlerIn::Response(node_address, Box::new(response)))
-                {
-                    warn!("Failed to send response {}", e)
+                if let Ok(port) = src.port().try_into() {
+                    let response = Response {
+                        id,
+                        body: ResponseBody::Pong {
+                            enr_seq: self.local_enr.read().seq(),
+                            ip: src.ip(),
+                            port,
+                        },
+                    };
+                    debug!("Sending PONG response to {}", node_address);
+                    if let Err(e) = self
+                        .handler_send
+                        .send(HandlerIn::Response(node_address, Box::new(response)))
+                    {
+                        warn!("Failed to send response {}", e);
+                    }
+                } else {
+                    warn!("The src port number should be non zero. {src}");
                 }
             }
             RequestBody::Talk { protocol, request } => {
@@ -778,12 +783,16 @@ impl Service {
                 ResponseBody::Pong { enr_seq, ip, port } => {
                     // Send the response to the user, if they are who asked
                     if let Some(CallbackResponse::Pong(callback)) = active_request.callback {
-                        let response = Pong { enr_seq, ip, port };
+                        let response = Pong {
+                            enr_seq,
+                            ip,
+                            port: port.get(),
+                        };
                         if let Err(e) = callback.send(Ok(response)) {
                             warn!("Failed to send callback response {:?}", e)
                         };
                     } else {
-                        let socket = SocketAddr::new(ip, port);
+                        let socket = SocketAddr::new(ip, port.get());
                         // perform ENR majority-based update if required.
 
                         // Only count votes that from peers we have contacted.

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -144,7 +144,7 @@ async fn test_updating_connection_on_ping() {
         body: ResponseBody::Pong {
             enr_seq: 2,
             ip: ip2.into(),
-            port: DEFAULT_UDP_PORT.try_into().unwrap(),
+            port: 9000.try_into().unwrap(),
         },
     };
 

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -144,7 +144,7 @@ async fn test_updating_connection_on_ping() {
         body: ResponseBody::Pong {
             enr_seq: 2,
             ip: ip2.into(),
-            port: DEFAULT_UDP_PORT,
+            port: DEFAULT_UDP_PORT.try_into().unwrap(),
         },
     };
 


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

This PR closes https://github.com/sigp/discv5/issues/217.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->


In this PR, if we received a PONG response with zero port number, the following logs will be output, and the response will be ignored.

```
2023-10-19T22:22:23.827733Z DEBUG discv5::rpc: The port number should be non zero: 0
2023-10-19T22:22:23.827762Z  WARN discv5::handler: Failed to decode message. Error: Custom("PONG response port number invalid"), Node: 0xb862..63b1, addr: 16.0.0.3:9000
```

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
