### PR TITLE
Adjust some logs

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -908,8 +908,8 @@ impl Handler {
             }
         } else {
             warn!(
-                "Received an authenticated header without a matching WHOAREYOU request. {}",
-                node_address
+                node_id = %node_address.node_id, addr = %node_address.socket_addr,
+                "Received an authenticated header without a matching WHOAREYOU request",
             );
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1528,8 +1528,12 @@ impl Service {
                 let request_body = query.target().rpc_request(return_peer);
                 Poll::Ready(QueryEvent::Waiting(query.id(), node_id, request_body))
             }
-            debug!("Query id: {:?} timed out", query.id());
-            QueryPoolState::Timeout(query) => Poll::Ready(QueryEvent::TimedOut(Box::new(query))),
+            
+            QueryPoolState::Timeout(query) => {
+                let query_id = query.id().0;
+                debug!(%query_id, "Query timed out");
+                Poll::Ready(QueryEvent::TimedOut(Box::new(query)))
+            },
             QueryPoolState::Waiting(None) | QueryPoolState::Idle => Poll::Pending,
         })
         .await

--- a/src/service.rs
+++ b/src/service.rs
@@ -1529,11 +1529,7 @@ impl Service {
                 Poll::Ready(QueryEvent::Waiting(query.id(), node_id, request_body))
             }
             
-            QueryPoolState::Timeout(query) => {
-                let query_id = query.id().0;
-                debug!(%query_id, "Query timed out");
-                Poll::Ready(QueryEvent::TimedOut(Box::new(query)))
-            },
+            QueryPoolState::Timeout(query) => Poll::Ready(QueryEvent::TimedOut(Box::new(query))),
             QueryPoolState::Waiting(None) | QueryPoolState::Idle => Poll::Pending,
         })
         .await

--- a/src/service.rs
+++ b/src/service.rs
@@ -1529,10 +1529,7 @@ impl Service {
                 let request_body = query.target().rpc_request(return_peer);
                 Poll::Ready(QueryEvent::Waiting(query.id(), node_id, request_body))
             }
-            QueryPoolState::Timeout(query) => {
-                warn!("Query id: {:?} timed out", query.id());
-                Poll::Ready(QueryEvent::TimedOut(Box::new(query)))
-            }
+            QueryPoolState::Timeout(query) => Poll::Ready(QueryEvent::TimedOut(Box::new(query))),
             QueryPoolState::Waiting(None) | QueryPoolState::Idle => Poll::Pending,
         })
         .await

--- a/src/service.rs
+++ b/src/service.rs
@@ -1528,7 +1528,7 @@ impl Service {
                 let request_body = query.target().rpc_request(return_peer);
                 Poll::Ready(QueryEvent::Waiting(query.id(), node_id, request_body))
             }
-            
+
             QueryPoolState::Timeout(query) => Poll::Ready(QueryEvent::TimedOut(Box::new(query))),
             QueryPoolState::Waiting(None) | QueryPoolState::Idle => Poll::Pending,
         })

--- a/src/service.rs
+++ b/src/service.rs
@@ -1528,6 +1528,7 @@ impl Service {
                 let request_body = query.target().rpc_request(return_peer);
                 Poll::Ready(QueryEvent::Waiting(query.id(), node_id, request_body))
             }
+            debug!("Query id: {:?} timed out", query.id());
             QueryPoolState::Timeout(query) => Poll::Ready(QueryEvent::TimedOut(Box::new(query))),
             QueryPoolState::Waiting(None) | QueryPoolState::Idle => Poll::Pending,
         })


### PR DESCRIPTION
## Description
Adjust some common logs seen on https://github.com/sigp/lighthouse/pull/4979
- Query time out; Queries always have a callback, so this error is always informed in the form of an event, the caller can decide what to do with this
- Failed FINDNODE; unclear what kind of errors are happening. I suspect we will be downgrading this log eventually
- Blacklisting peer. Log was not very descriptive of what is actually going on
- IP mode info. Before we would only know this on start, not on creation. Since this is no longer the case the two logs (start and creation) can be merged

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
