### PR TITLE
make tracing-subscriber a dev dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3"
 uint = { version = "0.9", default-features = false }
 rlp = "0.5"
 # This version must be kept up to date do it uses the same dependencies as ENR
-hkdf = "0.12" 
+hkdf = "0.12"
 hex = "0.4"
 fnv = "1"
 arrayvec = "0.7"
@@ -32,20 +32,20 @@ lazy_static = "1"
 aes = { version = "0.7", features = ["ctr"] }
 aes-gcm = "0.9"
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 lru = "0.12"
 hashlink = "0.8"
 delay_map = "0.3"
 more-asserts = "0.3"
 
 [dev-dependencies]
-rand_07 = { package = "rand", version = "0.7" }
-quickcheck = "0.9"
-tokio = { version = "1", features = ["full"] }
-rand_xorshift = "0.3"
-rand_core = "0.6"
 clap = { version = "4", features = ["derive"] }
 if-addrs = "0.10"
+quickcheck = "0.9"
+rand_07 = { package = "rand", version = "0.7" }
+rand_core = "0.6"
+rand_xorshift = "0.3"
+tokio = { version = "1", features = ["full"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 libp2p = ["dep:libp2p"]


### PR DESCRIPTION
## Description

we don't use `tracing-subscriber` in discv5. Having this as a dependency potentially created a duplicated dep that is not even used

## Notes & open questions

na

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
