### PR TITLE
Draft proptest for tagging of keys in lru_time_cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rand_xorshift = "0.3.0"
 rand_core = "0.6.3"
 clap = { version = "3.1", features = ["derive"] }
 if-addrs = "0.10.1"
+proptest = "1.1.0"
 
 [features]
 libp2p = ["libp2p-core", "libp2p-identity"]

--- a/src/lru_time_cache.rs
+++ b/src/lru_time_cache.rs
@@ -155,10 +155,10 @@ impl<K: Clone + Eq + Hash, V> LruTimeCache<K, V> {
 
 #[cfg(test)]
 mod tests {
-    use crate::lru_time_cache::LruTimeCache;
-    use std::time::Duration;
+   use crate::lru_time_cache::LruTimeCache;
     use proptest::prelude::*;
     use rand::Rng;
+    use std::time::Duration;
 
     //Generates strategy for vector of keys and vector of values to use in tests
     //Range hardcoded as 1 to 1000, length passed from main test function
@@ -204,8 +204,7 @@ mod tests {
                     //If it is, it will update value to current iteration value and tagged to true
                     //If it is not, it will add a new tagged key value pair to cache
                     1 => {
-                        if test_cache_k.iter().any(|&find| find==test_keys[i]) {
-                            let existing_index = test_cache_k.iter().position(|&find| find==test_keys[i]).unwrap();
+                        if let Some(existing_index) = test_cache_k.iter().position(|&find| find==test_keys[i]) {
                             cache.insert_tagged(test_keys[i], test_values[i]);
                             test_cache_v[existing_index] = test_values[i];
                             test_cache_bool[existing_index] = true;
@@ -222,8 +221,7 @@ mod tests {
                     //If it is, it will update value to current iteration value and tagged to false
                     //If it is not, it will add a new untagged key value pair to cache
                     2 => {
-                        if test_cache_k.iter().any(|&find| find==test_keys[i]) {
-                            let existing_index = test_cache_k.iter().position(|&find| find==test_keys[i]).unwrap();
+                        if let Some(existing_index) = test_cache_k.iter().position(|&find| find==test_keys[i]) {
                             cache.insert(test_keys[i], test_values[i]);
                             test_cache_v[existing_index] = test_values[i];
                             test_cache_bool[existing_index] = false;
@@ -241,27 +239,16 @@ mod tests {
                     //If cache has single element, removes that element
                     //If cache has multiple elements, selects one at random to remove
                     3 => {
-                        if test_cache_k.len() == 0 {
+                        if test_cache_k.is_empty() {
                             println!("Cache empty - Insert tagged - k {} , v {}", test_keys[i], test_values[i]);
                             cache.insert_tagged(test_keys[i], test_values[i]);
                             test_cache_k.push(test_keys[i]);
                             test_cache_v.push(test_values[i]);
                             test_cache_bool.push(true);
 
-                        } if test_cache_k.len() == 1 {
-                            let rand_key: i32 = test_cache_k[0];
-                            let rand_val: i32 = test_cache_v[0];
-                            let rand_bool: bool = test_cache_bool[0];
-                            let ret_value = cache.remove(&rand_key).unwrap();
-                            test_cache_k.remove(0);
-                            test_cache_v.remove(0);
-                            test_cache_bool.remove(0);
-                            println!("Remove - k {} , v {}, tagged {}", rand_key, rand_val, rand_bool);
-
                         } else {
                             let test_cache_length = test_cache_k.len();
-                            let mut rand_index = rand::thread_rng().gen_range(1..test_cache_length);
-                            rand_index = rand_index - 1;
+                            let rand_index = rand::thread_rng().gen_range(0..test_cache_length);
                             let rand_key: i32 = test_cache_k[rand_index];
                             let rand_val: i32 = test_cache_v[rand_index];
                             let rand_bool: bool = test_cache_bool[rand_index];
@@ -286,14 +273,9 @@ mod tests {
                             let ret_value = ret_value.unwrap();
                             println!("Cache returned {}", ret_value);
 
-                        } if test_cache_k.len() == 1 {
-                            let ret_value = cache.get_mut(&test_cache_k[0]).unwrap();
-                            println!("Attempt get with k {} Cache returned {} expected {}", test_cache_k[0], ret_value, test_cache_v[0]);
-
                         } else {
                             let test_cache_length = test_cache_k.len();
-                            let mut rand_index = rand::thread_rng().gen_range(1..test_cache_length);
-                            rand_index = rand_index - 1;
+                            let rand_index = rand::thread_rng().gen_range(0..test_cache_length);
                             let rand_key: i32 = test_cache_k[rand_index];
                             let rand_val: i32 = test_cache_v[rand_index];
                             let ret_value = cache.get_mut(&rand_key).unwrap();


### PR DESCRIPTION
## Description

- Include proptest v1.1.0 in cargo.toml dev dependencies
- Draft proptest in lru_time_cache that tries to panic tagging of key values

## Notes & open questions

- Need to implement checking of keys in cache expiring
- Code needs significant factoring and optimisation
- Prints for debug need to be removed 
