### PR TITLE
Fix warnings and bump libp2p

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
-version = "0.4.0"
+version = "0.4.1"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "Apache-2.0"
 repository = "https://github.com/sigp/discv5"
@@ -14,7 +14,7 @@ exclude = [".gitignore", ".github/*"]
 [dependencies]
 enr = { version = "0.10", features = ["k256", "ed25519"] }
 tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
-libp2p = { version = "0.52", features = ["ed25519", "secp256k1"], optional = true }
+libp2p = { version = "0.53", features = ["ed25519", "secp256k1"], optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 futures = "0.3"
 uint = { version = "0.9", default-features = false }

--- a/src/handler/request_call.rs
+++ b/src/handler/request_call.rs
@@ -1,4 +1,4 @@
-pub use crate::node_info::{NodeAddress, NodeContact};
+pub use crate::node_info::NodeContact;
 use crate::{
     packet::Packet,
     rpc::{Request, RequestBody},

--- a/src/kbucket/entry.rs
+++ b/src/kbucket/entry.rs
@@ -25,9 +25,7 @@
 //! representing the nodes participating in the Kademlia DHT.
 
 pub use super::{
-    bucket::{
-        AppliedPending, ConnectionState, InsertResult, Node, NodeStatus, MAX_NODES_PER_BUCKET,
-    },
+    bucket::{AppliedPending, ConnectionState, InsertResult, Node, NodeStatus},
     key::*,
     ConnectionDirection,
 };


### PR DESCRIPTION
This PR fixes some warnings in master and bumps the libp2p version. 


This also bumps the discv5 crate to 4.1