### PR TITLE
Merge `master` into `discv5.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
-version = "0.3.0"
+version = "0.4.1"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "Apache-2.0"
 repository = "https://github.com/sigp/discv5"
@@ -12,43 +12,42 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.8.1", features = ["k256", "ed25519"] }
-tokio = { version = "1.15.0", features = ["net", "sync", "macros", "rt"] }
-libp2p-core = { version = "0.40.0", optional = true }
-libp2p-identity = { version = "0.2.1", features = ["ed25519", "secp256k1"], optional = true }
-zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
-futures = "0.3.19"
-uint = { version = "0.9.1", default-features = false }
-rlp = "0.5.1"
+enr = { version = "0.10", features = ["k256", "ed25519"] }
+tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
+libp2p = { version = "0.53", features = ["ed25519", "secp256k1"], optional = true }
+zeroize = { version = "1", features = ["zeroize_derive"] }
+futures = "0.3"
+uint = { version = "0.9", default-features = false }
+rlp = "0.5"
 # This version must be kept up to date do it uses the same dependencies as ENR
-hkdf = "0.12.3" 
-hex = "0.4.3"
-fnv = "1.0.7"
-arrayvec = "0.7.2"
-rand = { version = "0.8.4", package = "rand" }
-socket2 = "0.4.4"
-smallvec = "1.7.0"
-parking_lot = "0.11.2"
-lazy_static = "1.4.0"
-aes = { version = "0.7.5", features = ["ctr"] }
-aes-gcm = "0.9.4"
-tracing = { version = "0.1.29", features = ["log"] }
-tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-lru = {version = "0.7.1", default-features = false }
-hashlink = "0.7.0"
-delay_map = "0.3.0"
-more-asserts = "0.2.2"
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "display", "deref", "deref_mut"] }
+hkdf = "0.12"
+hex = "0.4"
+fnv = "1"
+arrayvec = "0.7"
+rand = { version = "0.8", package = "rand" }
+socket2 = "0.4"
+smallvec = "1"
+parking_lot = "0.11"
+lazy_static = "1"
+aes = { version = "0.7", features = ["ctr"] }
+aes-gcm = "0.9"
+tracing = { version = "0.1", features = ["log"] }
+lru = { version = "0.12", default-features = false }
+hashlink = "0.8"
+delay_map = "0.3"
+more-asserts = "0.3"
+derive_more = { version = "0.99", default-features = false, features = ["from", "display", "deref", "deref_mut"] }
 
 [dev-dependencies]
+clap = { version = "4", features = ["derive"] }
+if-addrs = "0.10"
+quickcheck = "0.9"
 rand_07 = { package = "rand", version = "0.7" }
-quickcheck = "0.9.2"
-tokio = { version = "1.15.0", features = ["full"] }
-rand_xorshift = "0.3.0"
-rand_core = "0.6.3"
-clap = { version = "3.1", features = ["derive"] }
-if-addrs = "0.10.1"
+rand_core = "0.6"
+rand_xorshift = "0.3"
+tokio = { version = "1", features = ["full"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-libp2p = ["libp2p-core", "libp2p-identity"]
+libp2p = ["dep:libp2p"]
 serde = ["enr/serde"]

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Status]][Crates Link]
 This is a rust implementation of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md)
 peer discovery protocol.
 
-Discovery v5 is a protocol designed for encrypted peer discovery (and topic advertisement tba). Each peer/node
-on the network is identified via it's `ENR` ([Ethereum Node
-Record](https://eips.ethereum.org/EIPS/eip-778)), which is essentially a signed key-value store
-containing the node's public key and optionally IP address and port.
+Discovery v5 is a protocol designed for encrypted peer discovery. Each peer/node on the network is
+identified via it's `ENR` ([Ethereum Node Record](https://eips.ethereum.org/EIPS/eip-778)), which
+is essentially a signed key-value store containing the node's public key and optionally IP address
+and port.
 
 Discv5 employs a kademlia-like routing table to store and manage discovered peers and topics. The
 protocol allows for external IP discovery in NAT environments through regular PING/PONG's with
@@ -37,13 +37,13 @@ For a simple CLI discovery service see [discv5-cli](https://github.com/AgeMannin
 A simple example of creating this service is as follows:
 
 ```rust
-   use discv5::{enr, enr::{CombinedKey, NodeId}, TokioExecutor, Discv5, Discv5ConfigBuilder};
+   use discv5::{enr, enr::{CombinedKey, NodeId}, TokioExecutor, Discv5, ConfigBuilder};
    use discv5::socket::ListenConfig;
    use std::net::SocketAddr;
 
    // construct a local ENR
    let enr_key = CombinedKey::generate_secp256k1();
-   let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+   let enr = enr::Enr::empty(&enr_key).unwrap();
 
    // build the tokio executor
    let mut runtime = tokio::runtime::Builder::new_multi_thread()
@@ -59,7 +59,7 @@ A simple example of creating this service is as follows:
    };
 
    // default configuration
-   let config = Discv5ConfigBuilder::new(listen_config).build();
+   let config = ConfigBuilder::new(listen_config).build();
 
    // construct the discv5 server
    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();

--- a/examples/custom_executor.rs
+++ b/examples/custom_executor.rs
@@ -9,7 +9,7 @@
 //! $ cargo run --example custom_executor <BASE64ENR>
 //! ```
 
-use discv5::{enr, enr::CombinedKey, Discv5, Discv5ConfigBuilder, Discv5Event, ListenConfig};
+use discv5::{enr, enr::CombinedKey, ConfigBuilder, Discv5, Event, ListenConfig};
 use std::net::Ipv4Addr;
 
 fn main() {
@@ -29,7 +29,7 @@ fn main() {
 
     let enr_key = CombinedKey::generate_secp256k1();
     // construct a local ENR
-    let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+    let enr = enr::Enr::empty(&enr_key).unwrap();
 
     // build the tokio executor
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -39,7 +39,7 @@ fn main() {
         .unwrap();
 
     // default configuration - uses the current executor
-    let config = Discv5ConfigBuilder::new(listen_config).build();
+    let config = ConfigBuilder::new(listen_config).build();
 
     // construct the discv5 server
     let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
@@ -72,10 +72,10 @@ fn main() {
 
         loop {
             match event_stream.recv().await {
-                Some(Discv5Event::SocketUpdated(addr)) => {
+                Some(Event::SocketUpdated(addr)) => {
                     println!("Nodes ENR socket address has been updated to: {addr:?}");
                 }
-                Some(Discv5Event::Discovered(enr)) => {
+                Some(Event::Discovered(enr)) => {
                     println!("A peer has been discovered: {}", enr.node_id());
                 }
                 _ => {}

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 use discv5::{
     enr,
     enr::{k256, CombinedKey},
-    Discv5, Discv5ConfigBuilder, Discv5Event, ListenConfig,
+    ConfigBuilder, Discv5, Event, ListenConfig,
 };
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -90,7 +90,7 @@ async fn main() {
     };
 
     let enr = {
-        let mut builder = enr::EnrBuilder::new("v4");
+        let mut builder = enr::Enr::builder();
         if let Some(ip4) = args.enr_ip4 {
             // if the given address is the UNSPECIFIED address we want to advertise localhost
             if ip4.is_unspecified() {
@@ -120,10 +120,10 @@ async fn main() {
     };
 
     // default configuration with packet filtering
-    // let config = Discv5ConfigBuilder::new(listen_config).enable_packet_filter().build();
+    // let config = ConfigBuilder::new(listen_config).enable_packet_filter().build();
 
     // default configuration without packet filtering
-    let config = Discv5ConfigBuilder::new(listen_config).build();
+    let config = ConfigBuilder::new(listen_config).build();
 
     info!("Node Id: {}", enr.node_id());
     if args.enr_ip6.is_some() || args.enr_ip4.is_some() {
@@ -192,18 +192,19 @@ async fn main() {
                     continue;
                 }
                 match discv5_ev {
-                    Discv5Event::Discovered(enr) => info!("Enr discovered {}", enr),
-                    Discv5Event::EnrAdded { enr, replaced: _ } => info!("Enr added {}", enr),
-                    Discv5Event::NodeInserted { node_id, replaced: _ } => info!("Node inserted {}", node_id),
-                    Discv5Event::SessionEstablished(enr, _) => info!("Session established {}", enr),
-                    Discv5Event::SocketUpdated(addr) => info!("Socket updated {}", addr),
-                    Discv5Event::TalkRequest(_) => info!("Talk request received"),
+                    Event::Discovered(enr) => info!("Enr discovered {}", enr),
+                    Event::EnrAdded { enr, replaced: _ } => info!("Enr added {}", enr),
+                    Event::NodeInserted { node_id, replaced: _ } => info!("Node inserted {}", node_id),
+                    Event::SessionEstablished(enr, _) => info!("Session established {}", enr),
+                    Event::SocketUpdated(addr) => info!("Socket updated {}", addr),
+                    Event::TalkRequest(_) => info!("Talk request received"),
                 };
             }
         }
     }
 }
 
+#[derive(Clone)]
 pub enum SocketKind {
     Ip4,
     Ip6,

--- a/examples/request_enr.rs
+++ b/examples/request_enr.rs
@@ -13,7 +13,7 @@
 //!
 //! This requires the "libp2p" feature.
 #[cfg(feature = "libp2p")]
-use discv5::Discv5ConfigBuilder;
+use discv5::ConfigBuilder;
 #[cfg(feature = "libp2p")]
 use discv5::ListenConfig;
 #[cfg(feature = "libp2p")]
@@ -43,10 +43,10 @@ async fn main() {
     // generate a new enr key
     let enr_key = CombinedKey::generate_secp256k1();
     // construct a local ENR
-    let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+    let enr = enr::Enr::empty(&enr_key).unwrap();
 
     // default discv5 configuration
-    let config = Discv5ConfigBuilder::new(listen_config).build();
+    let config = ConfigBuilder::new(listen_config).build();
 
     let multiaddr = std::env::args()
         .nth(1)

--- a/examples/simple_server.rs
+++ b/examples/simple_server.rs
@@ -10,7 +10,7 @@
 //! $ cargo run --example simple_server -- <ENR-IP> <ENR-PORT> <BASE64ENR>
 //! ```
 
-use discv5::{enr, enr::CombinedKey, Discv5, Discv5ConfigBuilder, Discv5Event, ListenConfig};
+use discv5::{enr, enr::CombinedKey, ConfigBuilder, Discv5, Event, ListenConfig};
 use std::net::Ipv4Addr;
 
 #[tokio::main]
@@ -46,7 +46,7 @@ async fn main() {
 
     // construct a local ENR
     let enr = {
-        let mut builder = enr::EnrBuilder::new("v4");
+        let mut builder = enr::Enr::builder();
         // if an IP was specified, use it
         if let Some(external_address) = address {
             builder.ip4(external_address);
@@ -72,7 +72,7 @@ async fn main() {
     }
 
     // default configuration
-    let config = Discv5ConfigBuilder::new(listen_config).build();
+    let config = ConfigBuilder::new(listen_config).build();
 
     // construct the discv5 server
     let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
@@ -104,10 +104,10 @@ async fn main() {
 
     loop {
         match event_stream.recv().await {
-            Some(Discv5Event::SocketUpdated(addr)) => {
+            Some(Event::SocketUpdated(addr)) => {
                 println!("Nodes ENR socket address has been updated to: {addr:?}");
             }
-            Some(Discv5Event::Discovered(enr)) => {
+            Some(Event::Discovered(enr)) => {
                 println!("A peer has been discovered: {}", enr.node_id());
             }
             _ => {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,8 +8,7 @@ use crate::{
 /// boostrap.
 const MIN_SESSIONS_UNREACHABLE_ENR: usize = 10;
 
-use std::num::NonZeroUsize;
-use std::{ops::RangeInclusive, time::Duration};
+use std::{num::NonZeroUsize, ops::RangeInclusive, time::Duration};
 
 /// Configuration parameters that define the performance of the discovery network.
 #[derive(Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use crate::{
 /// boostrap.
 const MIN_SESSIONS_UNREACHABLE_ENR: usize = 10;
 
+use std::num::NonZeroUsize;
 use std::{ops::RangeInclusive, time::Duration};
 
 /// Configuration parameters that define the performance of the discovery network.
@@ -38,7 +39,7 @@ pub struct Config {
     pub session_timeout: Duration,
 
     /// The maximum number of established sessions to maintain. Default: 1000.
-    pub session_cache_capacity: usize,
+    pub session_cache_capacity: NonZeroUsize,
 
     /// Updates the local ENR IP and port based on PONG responses from peers. Default: true.
     pub enr_update: bool,
@@ -140,7 +141,7 @@ impl ConfigBuilder {
             query_timeout: Duration::from_secs(60),
             request_retries: 1,
             session_timeout: Duration::from_secs(86400),
-            session_cache_capacity: 1000,
+            session_cache_capacity: NonZeroUsize::new(1000).expect("infallible"),
             enr_update: true,
             max_nodes_response: 16,
             enr_peer_update_min: 10,
@@ -211,7 +212,8 @@ impl ConfigBuilder {
 
     /// The maximum number of established sessions to maintain.
     pub fn session_cache_capacity(&mut self, capacity: usize) -> &mut Self {
-        self.config.session_cache_capacity = capacity;
+        self.config.session_cache_capacity =
+            NonZeroUsize::new(capacity).expect("session_cache_capacity must be greater than 0");
         self
     }
 
@@ -360,7 +362,7 @@ impl std::fmt::Debug for Config {
             .field("query_peer_timeout", &self.query_peer_timeout)
             .field("request_retries", &self.request_retries)
             .field("session_timeout", &self.session_timeout)
-            .field("session_cache_capacity", &self.session_cache_capacity)
+            .field("session_cache_capacity", &self.session_cache_capacity.get())
             .field("enr_update", &self.enr_update)
             .field("query_parallelism", &self.query_parallelism)
             .field("report_discovered_peers", &self.report_discovered_peers)

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use std::{ops::RangeInclusive, time::Duration};
 
 /// Configuration parameters that define the performance of the discovery network.
 #[derive(Clone)]
-pub struct Discv5Config {
+pub struct Config {
     /// Whether to enable the incoming packet filter. Default: false.
     pub enable_packet_filter: bool,
 
@@ -115,11 +115,11 @@ pub struct Discv5Config {
 }
 
 #[derive(Debug)]
-pub struct Discv5ConfigBuilder {
-    config: Discv5Config,
+pub struct ConfigBuilder {
+    config: Config,
 }
 
-impl Discv5ConfigBuilder {
+impl ConfigBuilder {
     pub fn new(listen_config: ListenConfig) -> Self {
         // This is only applicable if enable_packet_filter is set.
         let filter_rate_limiter = Some(
@@ -132,7 +132,7 @@ impl Discv5ConfigBuilder {
         );
 
         // set default values
-        let config = Discv5Config {
+        let config = Config {
             enable_packet_filter: false,
             request_timeout: Duration::from_secs(1),
             vote_duration: Duration::from_secs(30),
@@ -161,7 +161,7 @@ impl Discv5ConfigBuilder {
             listen_config,
         };
 
-        Discv5ConfigBuilder { config }
+        ConfigBuilder { config }
     }
 
     /// Whether to enable the incoming packet filter.
@@ -335,7 +335,7 @@ impl Discv5ConfigBuilder {
         self
     }
 
-    pub fn build(&mut self) -> Discv5Config {
+    pub fn build(&mut self) -> Config {
         // If an executor is not provided, assume a current tokio runtime is running.
         if self.config.executor.is_none() {
             self.config.executor = Some(Box::<crate::executor::TokioExecutor>::default());
@@ -350,9 +350,9 @@ impl Discv5ConfigBuilder {
     }
 }
 
-impl std::fmt::Debug for Discv5Config {
+impl std::fmt::Debug for Config {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Discv5Config")
+        f.debug_struct("Config")
             .field("filter_enabled", &self.enable_packet_filter)
             .field("request_timeout", &self.request_timeout)
             .field("vote_duration", &self.vote_duration)

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{socket::ListenConfig, Discv5, *};
-use enr::{k256, CombinedKey, Enr, EnrBuilder, EnrKey, NodeId};
+use enr::{k256, CombinedKey, Enr, EnrKey, NodeId};
 use rand_core::{RngCore, SeedableRng};
 use std::{
     collections::HashMap,
@@ -26,13 +26,9 @@ async fn build_nodes(n: usize, base_port: u16) -> Vec<Discv5> {
     for port in base_port..base_port + n as u16 {
         let enr_key = CombinedKey::generate_secp256k1();
         let listen_config = ListenConfig::Ipv4 { ip, port };
-        let config = Discv5ConfigBuilder::new(listen_config).build();
+        let config = ConfigBuilder::new(listen_config).build();
 
-        let enr = EnrBuilder::new("v4")
-            .ip4(ip)
-            .udp4(port)
-            .build(&enr_key)
-            .unwrap();
+        let enr = Enr::builder().ip4(ip).udp4(port).build(&enr_key).unwrap();
         // transport for building a swarm
         let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
         discv5.start().await.unwrap();
@@ -50,13 +46,9 @@ async fn build_nodes_from_keypairs(keys: Vec<CombinedKey>, base_port: u16) -> Ve
         let port = base_port + i as u16;
 
         let listen_config = ListenConfig::Ipv4 { ip, port };
-        let config = Discv5ConfigBuilder::new(listen_config).build();
+        let config = ConfigBuilder::new(listen_config).build();
 
-        let enr = EnrBuilder::new("v4")
-            .ip4(ip)
-            .udp4(port)
-            .build(&enr_key)
-            .unwrap();
+        let enr = Enr::builder().ip4(ip).udp4(port).build(&enr_key).unwrap();
 
         let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
         discv5.start().await.unwrap();
@@ -75,9 +67,9 @@ async fn build_nodes_from_keypairs_ipv6(keys: Vec<CombinedKey>, base_port: u16) 
             ip: Ipv6Addr::LOCALHOST,
             port,
         };
-        let config = Discv5ConfigBuilder::new(listen_config).build();
+        let config = ConfigBuilder::new(listen_config).build();
 
-        let enr = EnrBuilder::new("v4")
+        let enr = Enr::builder()
             .ip6(Ipv6Addr::LOCALHOST)
             .udp6(port)
             .build(&enr_key)
@@ -106,9 +98,9 @@ async fn build_nodes_from_keypairs_dual_stack(
             ipv6: Ipv6Addr::LOCALHOST,
             ipv6_port,
         };
-        let config = Discv5ConfigBuilder::new(listen_config).build();
+        let config = ConfigBuilder::new(listen_config).build();
 
-        let enr = EnrBuilder::new("v4")
+        let enr = Enr::builder()
             .ip4(Ipv4Addr::LOCALHOST)
             .udp4(ipv4_port)
             .ip6(Ipv6Addr::LOCALHOST)
@@ -124,7 +116,7 @@ async fn build_nodes_from_keypairs_dual_stack(
 }
 
 /// Generate `n` deterministic keypairs from a given seed.
-fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
+pub(crate) fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
     let mut keypairs = Vec::new();
     for i in 0..n {
         let sk = {
@@ -744,16 +736,12 @@ async fn test_table_limits() {
     let mut keypairs = generate_deterministic_keypair(12, 9487);
     let ip: Ipv4Addr = "127.0.0.1".parse().unwrap();
     let enr_key: CombinedKey = keypairs.remove(0);
-    let enr = EnrBuilder::new("v4")
-        .ip4(ip)
-        .udp4(9050)
-        .build(&enr_key)
-        .unwrap();
+    let enr = Enr::builder().ip4(ip).udp4(9050).build(&enr_key).unwrap();
     let listen_config = ListenConfig::Ipv4 {
         ip: enr.ip4().unwrap(),
         port: enr.udp4().unwrap(),
     };
-    let config = Discv5ConfigBuilder::new(listen_config).ip_limit().build();
+    let config = ConfigBuilder::new(listen_config).ip_limit().build();
 
     // let socket_addr = enr.udp_socket().unwrap();
     let discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
@@ -763,7 +751,7 @@ async fn test_table_limits() {
         .map(|i| {
             let ip: Ipv4Addr = Ipv4Addr::new(192, 168, 1, i as u8);
             let enr_key: CombinedKey = keypairs.remove(0);
-            EnrBuilder::new("v4")
+            Enr::builder()
                 .ip4(ip)
                 .udp4(9050 + i as u16)
                 .build(&enr_key)
@@ -782,11 +770,7 @@ async fn test_table_limits() {
 async fn test_bucket_limits() {
     let enr_key = CombinedKey::generate_secp256k1();
     let ip: Ipv4Addr = "127.0.0.1".parse().unwrap();
-    let enr = EnrBuilder::new("v4")
-        .ip4(ip)
-        .udp4(9500)
-        .build(&enr_key)
-        .unwrap();
+    let enr = Enr::builder().ip4(ip).udp4(9500).build(&enr_key).unwrap();
     let bucket_limit: usize = 2;
     // Generate `bucket_limit + 1` keypairs that go in `enr` node's 256th bucket.
     let keys = {
@@ -794,7 +778,7 @@ async fn test_bucket_limits() {
         for _ in 0..bucket_limit + 1 {
             loop {
                 let key = CombinedKey::generate_secp256k1();
-                let enr_new = EnrBuilder::new("v4").build(&key).unwrap();
+                let enr_new = Enr::empty(&key).unwrap();
                 let node_key: Key<NodeId> = enr.node_id().into();
                 let distance = node_key.log2_distance(&enr_new.node_id().into()).unwrap();
                 if distance == 256 {
@@ -810,7 +794,7 @@ async fn test_bucket_limits() {
         .map(|i| {
             let kp = &keys[i - 1];
             let ip: Ipv4Addr = Ipv4Addr::new(192, 168, 1, i as u8);
-            EnrBuilder::new("v4")
+            Enr::builder()
                 .ip4(ip)
                 .udp4(9500 + i as u16)
                 .build(kp)
@@ -822,7 +806,7 @@ async fn test_bucket_limits() {
         ip: enr.ip4().unwrap(),
         port: enr.udp4().unwrap(),
     };
-    let config = Discv5ConfigBuilder::new(listen_config).ip_limit().build();
+    let config = ConfigBuilder::new(listen_config).ip_limit().build();
 
     let discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
     for enr in enrs {

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 #[derive(Debug, From)]
 /// A general error that is used throughout the Discv5 library.
-pub enum Discv5Error {
+pub enum Error {
     /// An invalid message type was received.
     InvalidMessage,
     /// An invalid ENR was received.
@@ -60,11 +60,11 @@ pub enum Discv5Error {
 #[derive(Debug)]
 pub enum NatError {
     /// Initiator error.
-    Initiator(Discv5Error),
+    Initiator(Error),
     /// Relayer error.
-    Relay(Discv5Error),
+    Relay(Error),
     /// Target error.
-    Target(Discv5Error),
+    Target(Error),
 }
 
 macro_rules! impl_from_variant {
@@ -76,8 +76,8 @@ macro_rules! impl_from_variant {
         }
     };
 }
-impl_from_variant!(<T,>, tokio::sync::mpsc::error::SendError<T>, Discv5Error, Self::ServiceChannelClosed);
-impl_from_variant!(, NonContactable, Discv5Error, Self::InvalidEnr);
+impl_from_variant!(<T,>, tokio::sync::mpsc::error::SendError<T>, Error, Self::ServiceChannelClosed);
+impl_from_variant!(, NonContactable, Error, Self::InvalidEnr);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Types of packet errors.
@@ -162,7 +162,7 @@ pub enum QueryError {
     InvalidMultiaddr(String),
 }
 
-impl fmt::Display for Discv5Error {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")
     }

--- a/src/handler/active_requests.rs
+++ b/src/handler/active_requests.rs
@@ -1,68 +1,142 @@
 use super::*;
 use delay_map::HashMapDelay;
 use more_asserts::debug_unreachable;
+use std::collections::hash_map::Entry;
 
 pub(super) struct ActiveRequests {
     /// A list of raw messages we are awaiting a response from the remote.
-    active_requests_mapping: HashMapDelay<NodeAddress, RequestCall>,
+    active_requests_mapping: HashMap<NodeAddress, Vec<RequestCall>>,
     // WHOAREYOU messages do not include the source node id. We therefore maintain another
     // mapping of active_requests via message_nonce. This allows us to match WHOAREYOU
     // requests with active requests sent.
-    /// A mapping of all pending active raw requests message nonces to their NodeAddress.
-    active_requests_nonce_mapping: HashMap<MessageNonce, NodeAddress>,
+    /// A mapping of all active raw requests message nonces to their NodeAddress.
+    active_requests_nonce_mapping: HashMapDelay<MessageNonce, NodeAddress>,
 }
 
 impl ActiveRequests {
     pub fn new(request_timeout: Duration) -> Self {
         ActiveRequests {
-            active_requests_mapping: HashMapDelay::new(request_timeout),
-            active_requests_nonce_mapping: HashMap::new(),
+            active_requests_mapping: HashMap::new(),
+            active_requests_nonce_mapping: HashMapDelay::new(request_timeout),
         }
     }
 
+    /// Insert a new request into the active requests mapping.
     pub fn insert(&mut self, node_address: NodeAddress, request_call: RequestCall) {
         let nonce = *request_call.packet().message_nonce();
         self.active_requests_mapping
-            .insert(node_address.clone(), request_call);
+            .entry(node_address.clone())
+            .or_default()
+            .push(request_call);
         self.active_requests_nonce_mapping
             .insert(nonce, node_address);
     }
 
-    pub fn get(&self, node_address: &NodeAddress) -> Option<&RequestCall> {
-        self.active_requests_mapping.get(node_address)
-    }
+    /// Update the underlying packet for the request via message nonce.
+    pub fn update_packet(&mut self, old_nonce: MessageNonce, new_packet: Packet) {
+        let node_address =
+            if let Some(node_address) = self.active_requests_nonce_mapping.remove(&old_nonce) {
+                node_address
+            } else {
+                debug_unreachable!("expected to find nonce in active_requests_nonce_mapping");
+                error!("expected to find nonce in active_requests_nonce_mapping");
+                return;
+            };
 
-    pub fn remove_by_nonce(&mut self, nonce: &MessageNonce) -> Option<(NodeAddress, RequestCall)> {
-        match self.active_requests_nonce_mapping.remove(nonce) {
-            Some(node_address) => match self.active_requests_mapping.remove(&node_address) {
-                Some(request_call) => Some((node_address, request_call)),
-                None => {
-                    debug_unreachable!("A matching request call doesn't exist");
-                    error!("A matching request call doesn't exist");
-                    None
+        self.active_requests_nonce_mapping
+            .insert(new_packet.header.message_nonce, node_address.clone());
+
+        match self.active_requests_mapping.entry(node_address) {
+            Entry::Occupied(mut requests) => {
+                let maybe_request_call = requests
+                    .get_mut()
+                    .iter_mut()
+                    .find(|req| req.packet().message_nonce() == &old_nonce);
+
+                if let Some(request_call) = maybe_request_call {
+                    request_call.update_packet(new_packet);
+                } else {
+                    debug_unreachable!("expected to find request call in active_requests_mapping");
+                    error!("expected to find request call in active_requests_mapping");
                 }
-            },
-            None => None,
+            }
+            Entry::Vacant(_) => {
+                debug_unreachable!("expected to find node address in active_requests_mapping");
+                error!("expected to find node address in active_requests_mapping");
+            }
         }
     }
 
-    pub fn remove(&mut self, node_address: &NodeAddress) -> Option<RequestCall> {
-        match self.active_requests_mapping.remove(node_address) {
-            Some(request_call) => {
-                // Remove the associated nonce mapping.
-                match self
-                    .active_requests_nonce_mapping
-                    .remove(request_call.packet().message_nonce())
-                {
-                    Some(_) => Some(request_call),
-                    None => {
-                        debug_unreachable!("A matching nonce mapping doesn't exist");
-                        error!("A matching nonce mapping doesn't exist");
-                        None
-                    }
-                }
+    pub fn get(&self, node_address: &NodeAddress) -> Option<&Vec<RequestCall>> {
+        self.active_requests_mapping.get(node_address)
+    }
+
+    /// Remove a single request identified by its nonce.
+    pub fn remove_by_nonce(&mut self, nonce: &MessageNonce) -> Option<(NodeAddress, RequestCall)> {
+        let node_address = self.active_requests_nonce_mapping.remove(nonce)?;
+        match self.active_requests_mapping.entry(node_address.clone()) {
+            Entry::Vacant(_) => {
+                debug_unreachable!("expected to find node address in active_requests_mapping");
+                error!("expected to find node address in active_requests_mapping");
+                None
             }
-            None => None,
+            Entry::Occupied(mut requests) => {
+                let result = requests
+                    .get()
+                    .iter()
+                    .position(|req| req.packet().message_nonce() == nonce)
+                    .map(|index| (node_address, requests.get_mut().remove(index)));
+                if requests.get().is_empty() {
+                    requests.remove();
+                }
+                result
+            }
+        }
+    }
+
+    /// Remove all requests associated with a node.
+    pub fn remove_requests(&mut self, node_address: &NodeAddress) -> Option<Vec<RequestCall>> {
+        let requests = self.active_requests_mapping.remove(node_address)?;
+        // Account for node addresses in `active_requests_nonce_mapping` with an empty list
+        if requests.is_empty() {
+            debug_unreachable!("expected to find requests in active_requests_mapping");
+            return None;
+        }
+        for req in &requests {
+            if self
+                .active_requests_nonce_mapping
+                .remove(req.packet().message_nonce())
+                .is_none()
+            {
+                debug_unreachable!("expected to find req with nonce");
+                error!("expected to find req with nonce");
+            }
+        }
+        Some(requests)
+    }
+
+    /// Remove a single request identified by its id.
+    pub fn remove_request(
+        &mut self,
+        node_address: &NodeAddress,
+        id: &RequestId,
+    ) -> Option<RequestCall> {
+        match self.active_requests_mapping.entry(node_address.clone()) {
+            Entry::Vacant(_) => None,
+            Entry::Occupied(mut requests) => {
+                let index = requests.get().iter().position(|req| {
+                    let req_id: RequestId = req.id().into();
+                    &req_id == id
+                })?;
+                let request_call = requests.get_mut().remove(index);
+                if requests.get().is_empty() {
+                    requests.remove();
+                }
+                // Remove the associated nonce mapping.
+                self.active_requests_nonce_mapping
+                    .remove(request_call.packet().message_nonce());
+                Some(request_call)
+            }
         }
     }
 
@@ -80,10 +154,12 @@ impl ActiveRequests {
             }
         }
 
-        for (address, request) in self.active_requests_mapping.iter() {
-            let nonce = request.packet().message_nonce();
-            if !self.active_requests_nonce_mapping.contains_key(nonce) {
-                panic!("Address {} maps to request with nonce {:?}, which does not exist in `active_requests_nonce_mapping`", address, nonce);
+        for (address, requests) in self.active_requests_mapping.iter() {
+            for req in requests {
+                let nonce = req.packet().message_nonce();
+                if !self.active_requests_nonce_mapping.contains_key(nonce) {
+                    panic!("Address {} maps to request with nonce {:?}, which does not exist in `active_requests_nonce_mapping`", address, nonce);
+                }
             }
         }
     }
@@ -92,12 +168,27 @@ impl ActiveRequests {
 impl Stream for ActiveRequests {
     type Item = Result<(NodeAddress, RequestCall), String>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.active_requests_mapping.poll_next_unpin(cx) {
-            Poll::Ready(Some(Ok((node_address, request_call)))) => {
-                // Remove the associated nonce mapping.
-                self.active_requests_nonce_mapping
-                    .remove(request_call.packet().message_nonce());
-                Poll::Ready(Some(Ok((node_address, request_call))))
+        match self.active_requests_nonce_mapping.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok((nonce, node_address)))) => {
+                match self.active_requests_mapping.entry(node_address.clone()) {
+                    Entry::Vacant(_) => Poll::Ready(None),
+                    Entry::Occupied(mut requests) => {
+                        match requests
+                            .get()
+                            .iter()
+                            .position(|req| req.packet().message_nonce() == &nonce)
+                        {
+                            Some(index) => {
+                                let result = (node_address, requests.get_mut().remove(index));
+                                if requests.get().is_empty() {
+                                    requests.remove();
+                                }
+                                Poll::Ready(Some(Ok(result)))
+                            }
+                            None => Poll::Ready(None),
+                        }
+                    }
+                }
             }
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
             Poll::Ready(None) => Poll::Ready(None),

--- a/src/handler/crypto/mod.rs
+++ b/src/handler/crypto/mod.rs
@@ -6,7 +6,7 @@
 //! encryption and key-derivation algorithms. Future versions may abstract some of these to allow
 //! for different algorithms.
 use crate::{
-    error::Discv5Error,
+    error::Error,
     node_info::NodeContact,
     packet::{ChallengeData, MessageNonce},
 };
@@ -48,7 +48,7 @@ pub(crate) fn generate_session_keys(
     local_id: &NodeId,
     contact: &NodeContact,
     challenge_data: &ChallengeData,
-) -> Result<(Key, Key, Vec<u8>), Discv5Error> {
+) -> Result<(Key, Key, Vec<u8>), Error> {
     let (secret, ephem_pk) = {
         match contact.public_key() {
             CombinedPublicKey::Secp256k1(remote_pk) => {
@@ -57,9 +57,7 @@ pub(crate) fn generate_session_keys(
                 let ephem_pk = ephem_sk.verifying_key();
                 (secret, ephem_pk.to_sec1_bytes().to_vec())
             }
-            CombinedPublicKey::Ed25519(_) => {
-                return Err(Discv5Error::KeyTypeNotSupported("Ed25519"))
-            }
+            CombinedPublicKey::Ed25519(_) => return Err(Error::KeyTypeNotSupported("Ed25519")),
         }
     };
 
@@ -74,7 +72,7 @@ fn derive_key(
     first_id: &NodeId,
     second_id: &NodeId,
     challenge_data: &ChallengeData,
-) -> Result<(Key, Key), Discv5Error> {
+) -> Result<(Key, Key), Error> {
     let mut info = [0u8; INFO_LENGTH];
     info[0..26].copy_from_slice(KEY_AGREEMENT_STRING.as_bytes());
     info[26..26 + NODE_ID_LENGTH].copy_from_slice(&first_id.raw());
@@ -84,7 +82,7 @@ fn derive_key(
 
     let mut okm = [0u8; 2 * KEY_LENGTH];
     hk.expand(&info, &mut okm)
-        .map_err(|_| Discv5Error::KeyDerivationFailed)?;
+        .map_err(|_| Error::KeyDerivationFailed)?;
 
     let mut initiator_key: Key = Default::default();
     let mut recipient_key: Key = Default::default();
@@ -101,17 +99,17 @@ pub(crate) fn derive_keys_from_pubkey(
     remote_id: &NodeId,
     challenge_data: &ChallengeData,
     ephem_pubkey: &[u8],
-) -> Result<(Key, Key), Discv5Error> {
+) -> Result<(Key, Key), Error> {
     let secret = {
         match local_key {
             CombinedKey::Secp256k1(key) => {
                 // convert remote pubkey into secp256k1 public key
                 // the key type should match our own node record
                 let remote_pubkey = k256::ecdsa::VerifyingKey::from_sec1_bytes(ephem_pubkey)
-                    .map_err(|_| Discv5Error::InvalidRemotePublicKey)?;
+                    .map_err(|_| Error::InvalidRemotePublicKey)?;
                 ecdh(&remote_pubkey, key)
             }
-            CombinedKey::Ed25519(_) => return Err(Discv5Error::KeyTypeNotSupported("Ed25519")),
+            CombinedKey::Ed25519(_) => return Err(Error::KeyTypeNotSupported("Ed25519")),
         }
     };
 
@@ -127,7 +125,7 @@ pub(crate) fn sign_nonce(
     challenge_data: &ChallengeData,
     ephem_pubkey: &[u8],
     dst_id: &NodeId,
-) -> Result<Vec<u8>, Discv5Error> {
+) -> Result<Vec<u8>, Error> {
     let signing_message = generate_signing_nonce(challenge_data, ephem_pubkey, dst_id);
 
     match signing_key {
@@ -135,10 +133,10 @@ pub(crate) fn sign_nonce(
             let message = Sha256::new().chain_update(signing_message);
             let signature: Signature = key
                 .try_sign_digest(message)
-                .map_err(|e| Discv5Error::Error(format!("Failed to sign message: {e}")))?;
+                .map_err(|e| Error::Error(format!("Failed to sign message: {e}")))?;
             Ok(signature.to_vec())
         }
-        CombinedKey::Ed25519(_) => Err(Discv5Error::KeyTypeNotSupported("Ed25519")),
+        CombinedKey::Ed25519(_) => Err(Error::KeyTypeNotSupported("Ed25519")),
     }
 }
 
@@ -191,9 +189,9 @@ pub(crate) fn decrypt_message(
     message_nonce: MessageNonce,
     msg: &[u8],
     aad: &[u8],
-) -> Result<Vec<u8>, Discv5Error> {
+) -> Result<Vec<u8>, Error> {
     if msg.len() < 16 {
-        return Err(Discv5Error::DecryptionFailed(
+        return Err(Error::DecryptionFailed(
             "Message not long enough to contain a MAC".into(),
         ));
     }
@@ -201,7 +199,7 @@ pub(crate) fn decrypt_message(
     let aead = Aes128Gcm::new(GenericArray::from_slice(key));
     let payload = Payload { msg, aad };
     aead.decrypt(GenericArray::from_slice(&message_nonce), payload)
-        .map_err(|e| Discv5Error::DecryptionFailed(e.to_string()))
+        .map_err(|e| Error::DecryptionFailed(e.to_string()))
 }
 
 /* Encryption related functions */
@@ -213,11 +211,11 @@ pub(crate) fn encrypt_message(
     message_nonce: MessageNonce,
     msg: &[u8],
     aad: &[u8],
-) -> Result<Vec<u8>, Discv5Error> {
+) -> Result<Vec<u8>, Error> {
     let aead = Aes128Gcm::new(GenericArray::from_slice(key));
     let payload = Payload { msg, aad };
     aead.encrypt(GenericArray::from_slice(&message_nonce), payload)
-        .map_err(|e| Discv5Error::DecryptionFailed(e.to_string()))
+        .map_err(|e| Error::DecryptionFailed(e.to_string()))
 }
 
 #[cfg(test)]
@@ -225,7 +223,7 @@ mod tests {
     use crate::packet::DefaultProtocolId;
 
     use super::*;
-    use enr::{CombinedKey, EnrBuilder, EnrKey};
+    use enr::{CombinedKey, Enr, EnrKey};
     use std::convert::TryInto;
 
     fn hex_decode(x: &'static str) -> Vec<u8> {
@@ -343,12 +341,12 @@ mod tests {
         let node1_key = CombinedKey::generate_secp256k1();
         let node2_key = CombinedKey::generate_secp256k1();
 
-        let node1_enr = EnrBuilder::new("v4")
+        let node1_enr = Enr::builder()
             .ip("127.0.0.1".parse().unwrap())
             .udp4(9000)
             .build(&node1_key)
             .unwrap();
-        let node2_enr = EnrBuilder::new("v4")
+        let node2_enr = Enr::builder()
             .ip("127.0.0.1".parse().unwrap())
             .udp4(9000)
             .build(&node2_key)

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -329,7 +329,7 @@ impl Handler {
         // Attempt to bind to the socket before spinning up the send/recv tasks.
         let socket = Socket::new::<P>(socket_config).await?;
 
-        let sessions = LruTimeCache::new(session_timeout, Some(session_cache_capacity));
+        let sessions = LruTimeCache::new(session_timeout, Some(session_cache_capacity.get()));
 
         let nat = Nat::new(
             &listen_sockets,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -27,9 +27,9 @@
 //! Messages from a node on the network come by [`Socket`] and get the form of a [`HandlerOut`]
 //! and can be forwarded to the application layer via the send channel.
 use crate::{
-    config::Discv5Config,
+    config::Config,
     discv5::PERMIT_BAN_LIST,
-    error::{Discv5Error, NatError, RequestError},
+    error::{Error, NatError, RequestError},
     packet::{ChallengeData, IdNonce, MessageNonce, Packet, PacketKind, ProtocolIdentity},
     rpc::{
         Message, Payload, RelayInitNotification, RelayMsgNotification, Request, RequestBody,
@@ -42,6 +42,7 @@ use crate::{
 use delay_map::HashMapDelay;
 use enr::{CombinedKey, NodeId};
 use futures::prelude::*;
+use more_asserts::debug_unreachable;
 use parking_lot::RwLock;
 use smallvec::SmallVec;
 use std::{
@@ -202,6 +203,15 @@ struct PendingRequest {
     request: RequestBody,
 }
 
+impl From<&HandlerReqId> for RequestId {
+    fn from(id: &HandlerReqId) -> Self {
+        match id {
+            HandlerReqId::Internal(id) => id.clone(),
+            HandlerReqId::External(id) => id.clone(),
+        }
+    }
+}
+
 /// Process to handle handshakes and sessions established from raw RPC communications between nodes.
 pub struct Handler {
     /// Configuration for the discv5 service.
@@ -213,7 +223,7 @@ pub struct Handler {
     enr: Arc<RwLock<Enr>>,
     /// The key to sign the ENR and set up encrypted communication with peers.
     key: Arc<RwLock<CombinedKey>>,
-    /// Pending raw requests.
+    /// Active requests that are awaiting a response.
     active_requests: ActiveRequests,
     /// The expected responses by SocketAddr which allows packets to pass the underlying filter.
     filter_expected_responses: Arc<RwLock<HashMap<SocketAddr, usize>>>,
@@ -250,7 +260,7 @@ impl Handler {
     pub async fn spawn<P: ProtocolIdentity>(
         enr: Arc<RwLock<Enr>>,
         key: Arc<RwLock<CombinedKey>>,
-        config: Discv5Config,
+        config: Config,
     ) -> Result<HandlerReturn, std::io::Error> {
         let (exit_sender, exit) = oneshot::channel();
         // create the channels to send/receive messages from the application
@@ -265,7 +275,7 @@ impl Handler {
         // The local node id
         let node_id = enr.read().node_id();
 
-        let Discv5Config {
+        let Config {
             enable_packet_filter,
             filter_rate_limiter,
             filter_max_nodes_per_ip,
@@ -421,13 +431,13 @@ impl Handler {
                 Some(inbound_packet) = self.socket.recv.recv() => {
                     self.process_inbound_packet::<P>(inbound_packet).await;
                 }
-                Some(Ok((node_address, pending_request))) = self.active_requests.next() => {
-                    self.handle_request_timeout::<P>(node_address, pending_request).await;
+                Some(Ok((node_address, active_request))) = self.active_requests.next() => {
+                    self.handle_request_timeout::<P>(node_address, active_request).await;
                 }
                 Some(Ok((node_address, _challenge))) = self.active_challenges.next() => {
                     // A challenge has expired. There could be pending requests awaiting this
                     // challenge. We process them here
-                    self.send_next_request::<P>(node_address).await;
+                    self.send_pending_requests::<P>(&node_address).await;
                 }
                 Some(Ok(peer_socket)) = self.nat.hole_punch_tracker.next() => {
                     if self.nat.is_behind_nat == Some(false) {
@@ -492,7 +502,7 @@ impl Handler {
                     socket_addr: inbound_packet.src_address,
                     node_id: src_id,
                 };
-                self.handle_message::<P>(
+                self.handle_message(
                     node_address,
                     message_nonce,
                     &inbound_packet.message,
@@ -559,9 +569,7 @@ impl Handler {
                     .on_request_time_out::<P>(relay, local_enr, nonce, target)
                     .await
                 {
-                    Err(NatError::Initiator(Discv5Error::SessionAlreadyEstablished(
-                        node_address,
-                    ))) => {
+                    Err(NatError::Initiator(Error::SessionAlreadyEstablished(node_address))) => {
                         debug!("Session to peer already established, aborting hole punch attempt. Peer: {node_address}");
                     }
                     Err(e) => {
@@ -606,10 +614,10 @@ impl Handler {
             return Err(RequestError::SelfRequest);
         }
 
-        // If there is already an active request or an active challenge (WHOAREYOU sent) for this
-        // node, add to pending requests
-        if self.active_requests.get(&node_address).is_some()
-            || self.active_challenges.get(&node_address).is_some()
+        // If there is already an active challenge (WHOAREYOU sent) for this node, or if we are
+        // awaiting a session with this node to be established, add the request to pending requests.
+        if self.active_challenges.get(&node_address).is_some()
+            || self.is_awaiting_session_to_be_established(&node_address)
         {
             trace!("Request queued for node: {}", node_address);
             self.pending_requests
@@ -637,14 +645,13 @@ impl Handler {
                     .map_err(|e| RequestError::EncryptionFailed(format!("{e:?}")))?;
                 (packet, false)
             } else {
-                // No session exists, start a new handshake
+                // No session exists, start a new handshake initiating a new session
                 trace!(
                     "Starting session. Sending random packet to: {}",
                     node_address
                 );
                 let packet =
                     Packet::new_random(&self.node_id).map_err(RequestError::EntropyFailure)?;
-                // We are initiating a new session
                 (packet, true)
             }
         };
@@ -831,6 +838,7 @@ impl Handler {
         // All sent requests must have an associated node_id. Therefore the following
         // must not panic.
         let node_address = request_call.contact().node_address();
+        let auth_message_nonce = auth_packet.header.message_nonce;
 
         // Keep track if the ENR is reachable. In the case we don't know the ENR, we assume its
         // fine.
@@ -850,7 +858,11 @@ impl Handler {
                 enr_not_reachable = Nat::is_enr_reachable(&enr);
 
                 // We already know the ENR. Send the handshake response packet
-                trace!("Sending Authentication response to node: {}", node_address);
+                trace!(
+                    "Sending Authentication response to node: {} ({:?})",
+                    node_address,
+                    request_call.id()
+                );
                 request_call.update_packet(auth_packet.clone());
                 request_call.set_handshake_sent();
                 request_call.set_initiating_session(false);
@@ -868,7 +880,11 @@ impl Handler {
 
                 // Send the Auth response
                 let contact = request_call.contact().clone();
-                trace!("Sending Authentication response to node: {}", node_address);
+                trace!(
+                    "Sending Authentication response to node: {} ({:?})",
+                    node_address,
+                    request_call.id()
+                );
                 request_call.update_packet(auth_packet.clone());
                 request_call.set_handshake_sent();
                 // Reinsert the request_call
@@ -886,7 +902,13 @@ impl Handler {
                 }
             }
         }
-        self.new_session(node_address, session, enr_not_reachable);
+        self.new_session::<P>(
+            node_address.clone(),
+            session,
+            Some(auth_message_nonce),
+            enr_not_reachable,
+        )
+        .await;
     }
 
     /// Verifies a Node ENR to it's observed address. If it fails, any associated session is also
@@ -957,6 +979,8 @@ impl Handler {
                 most_recent_enr,
             ) {
                 Ok((mut session, enr)) => {
+                    // Remove the expected response for the challenge.
+                    self.remove_expected_response(node_address.socket_addr);
                     // Receiving an AuthResponse must give us an up-to-date view of the node ENR.
                     // Verify the ENR is valid
                     if self.verify_enr(&enr, &node_address) {
@@ -970,20 +994,26 @@ impl Handler {
                             ConnectionDirection::Incoming,
                         )
                         .await;
-                        self.new_session(node_address.clone(), session, enr_not_reachable);
+                        // When (re-)establishing a session from an outgoing challenge, we do not need
+                        // to filter out this request from active requests, so we do not pass
+                        // the message nonce on to `new_session`.
+                        self.new_session::<P>(
+                            node_address.clone(),
+                            session,
+                            None,
+                            enr_not_reachable,
+                        )
+                        .await;
                         self.nat
                             .new_peer_latest_relay_cache
                             .pop(&node_address.node_id);
-                        self.handle_message::<P>(
+                        self.handle_message(
                             node_address.clone(),
                             message_nonce,
                             message,
                             authenticated_data,
                         )
                         .await;
-                        // We could have pending messages that were awaiting this session to be
-                        // established. If so process them.
-                        self.send_next_request::<P>(node_address).await;
                     } else {
                         // IP's or NodeAddress don't match. Drop the session.
                         warn!(
@@ -1028,7 +1058,7 @@ impl Handler {
                         }
                     }
                 }
-                Err(Discv5Error::InvalidChallengeSignature(challenge)) => {
+                Err(Error::InvalidChallengeSignature(challenge)) => {
                     warn!(
                         "Authentication header contained invalid signature. Ignoring packet from: {}",
                         node_address
@@ -1047,51 +1077,105 @@ impl Handler {
             }
         } else {
             warn!(
-                "Received an authenticated header without a matching WHOAREYOU request. {}",
-                node_address
+                node_id = %node_address.node_id, addr = %node_address.socket_addr,
+                "Received an authenticated header without a matching WHOAREYOU request",
             );
         }
     }
 
-    async fn send_next_request<P: ProtocolIdentity>(&mut self, node_address: NodeAddress) {
-        // ensure we are not over writing any existing requests
-        if self.active_requests.get(&node_address).is_none() {
-            if let std::collections::hash_map::Entry::Occupied(mut entry) =
-                self.pending_requests.entry(node_address)
+    /// Send all pending requests corresponding to the given node address, that were waiting for a
+    /// new session to be established or when an active outgoing challenge has expired.
+    async fn send_pending_requests<P: ProtocolIdentity>(&mut self, node_address: &NodeAddress) {
+        let pending_requests = self
+            .pending_requests
+            .remove(node_address)
+            .unwrap_or_default();
+        for req in pending_requests {
+            trace!(
+                "Sending pending request {} to {node_address}. {}",
+                RequestId::from(&req.request_id),
+                req.request,
+            );
+            if let Err(request_error) = self
+                .send_request::<P>(req.contact, req.request_id.clone(), req.request)
+                .await
             {
-                // If it exists, there must be a request here
-                let PendingRequest {
-                    contact,
-                    request_id,
-                    request,
-                } = entry.get_mut().remove(0);
-                if entry.get().is_empty() {
-                    entry.remove();
-                }
-                trace!("Sending next awaiting message. Node: {}", contact);
-                if let Err(request_error) = self
-                    .send_request::<P>(contact, request_id.clone(), request)
-                    .await
-                {
-                    warn!("Failed to send next awaiting request {}", request_error);
-                    // Inform the service that the request failed
-                    match request_id {
-                        HandlerReqId::Internal(_) => {
-                            // An internal request could not be sent. For now we do nothing about
-                            // this.
-                        }
-                        HandlerReqId::External(id) => {
-                            if let Err(e) = self
-                                .service_send
-                                .send(HandlerOut::RequestFailed(id, request_error))
-                                .await
-                            {
-                                warn!("Failed to inform that request failed {}", e);
-                            }
+                warn!("Failed to send next pending request {request_error}");
+                // Inform the service that the request failed
+                match req.request_id {
+                    HandlerReqId::Internal(_) => {
+                        // An internal request could not be sent. For now we do nothing about
+                        // this.
+                    }
+                    HandlerReqId::External(id) => {
+                        if let Err(e) = self
+                            .service_send
+                            .send(HandlerOut::RequestFailed(id, request_error))
+                            .await
+                        {
+                            warn!("Failed to inform that request failed {e}");
                         }
                     }
                 }
             }
+        }
+    }
+
+    /// Replays all active requests for the given node address, in the case that a new session has
+    /// been established. If an optional message nonce is provided, the corresponding request will
+    /// be skipped, eg. the request that established the new session.
+    async fn replay_active_requests<P: ProtocolIdentity>(
+        &mut self,
+        node_address: &NodeAddress,
+        // Optional message nonce to filter out the request used to establish the session.
+        message_nonce: Option<MessageNonce>,
+    ) {
+        trace!(
+            "Replaying active requests. {}, {:?}",
+            node_address,
+            message_nonce
+        );
+
+        let packets = if let Some(session) = self.sessions.get_mut(node_address) {
+            let mut packets = vec![];
+            for request_call in self
+                .active_requests
+                .get(node_address)
+                .unwrap_or(&vec![])
+                .iter()
+                .filter(|req| {
+                    // Except the active request that was used to establish the new session, as it has
+                    // already been handled and shouldn't be replayed.
+                    if let Some(nonce) = message_nonce.as_ref() {
+                        req.packet().message_nonce() != nonce
+                    } else {
+                        true
+                    }
+                })
+            {
+                if let Ok(new_packet) =
+                    session.encrypt_message::<P>(self.node_id, &request_call.encode())
+                {
+                    packets.push((*request_call.packet().message_nonce(), new_packet));
+                } else {
+                    error!(
+                        "Failed to re-encrypt packet while replaying active request with id: {:?}",
+                        request_call.id()
+                    );
+                }
+            }
+
+            packets
+        } else {
+            debug_unreachable!("Attempted to replay active requests but session doesn't exist.");
+            error!("Attempted to replay active requests but session doesn't exist.");
+            return;
+        };
+
+        for (old_nonce, new_packet) in packets {
+            self.active_requests
+                .update_packet(old_nonce, new_packet.clone());
+            self.send(node_address.clone(), new_packet).await;
         }
     }
 
@@ -1107,7 +1191,7 @@ impl Handler {
         let Some(session) = self.sessions.get_mut(&node_address) else {
             warn!(
                 "Dropping message. Error: {}, {}",
-                Discv5Error::SessionNotEstablished,
+                Error::SessionNotEstablished,
                 node_address
             );
             return;
@@ -1139,7 +1223,7 @@ impl Handler {
         };
 
         match message {
-            Message::Response(response) => self.handle_response::<P>(node_address, response).await,
+            Message::Response(response) => self.handle_response(node_address, response).await,
             Message::RelayInitNotification(notification) => {
                 let initiator_node_id = notification.initiator_enr().node_id();
                 if initiator_node_id != node_address.node_id {
@@ -1183,7 +1267,8 @@ impl Handler {
     }
 
     /// Handle a standard message that does not contain an authentication header.
-    async fn handle_message<P: ProtocolIdentity>(
+    #[allow(clippy::single_match)]
+    async fn handle_message(
         &mut self,
         node_address: NodeAddress,
         message_nonce: MessageNonce,
@@ -1250,7 +1335,7 @@ impl Handler {
                 Message::Response(response) => {
                     // Accept response in Message packet for backwards compatibility
                     warn!("Received a response in a `Message` packet, should be sent in a `SessionMessage`");
-                    self.handle_response::<P>(node_address, response).await
+                    self.handle_response(node_address, response).await
                 }
                 Message::RelayInitNotification(_) | Message::RelayMsgNotification(_) => {
                     warn!(
@@ -1283,18 +1368,14 @@ impl Handler {
 
     /// Handles a response to a request. Re-inserts the request call if the response is a multiple
     /// Nodes response.
-    async fn handle_response<P: ProtocolIdentity>(
-        &mut self,
-        node_address: NodeAddress,
-        response: Response,
-    ) {
+    async fn handle_response(&mut self, node_address: NodeAddress, response: Response) {
         // Sessions could be awaiting an ENR response. Check if this response matches
         // this
         // check if we have an available session
         let Some(session) = self.sessions.get_mut(&node_address) else {
             warn!(
                 "Dropping response. Error: {}, {}",
-                Discv5Error::SessionNotEstablished,
+                Error::SessionNotEstablished,
                 node_address
             );
             return;
@@ -1332,22 +1413,11 @@ impl Handler {
         // Handle standard responses
 
         // Find a matching request, if any
-        if let Some(mut request_call) = self.active_requests.remove(&node_address) {
-            let id = match request_call.id() {
-                HandlerReqId::Internal(id) | HandlerReqId::External(id) => id,
-            };
-            if id != &response.id {
-                trace!(
-                    "Received an RPC Response to an unknown request. Likely late response. {}",
-                    node_address
-                );
-                // add the request back and reset the timer
-                self.active_requests.insert(node_address, request_call);
-                return;
-            }
-
+        if let Some(mut request_call) = self
+            .active_requests
+            .remove_request(&node_address, &response.id)
+        {
             // The response matches a request
-
             // Check to see if this is a Nodes response, in which case we may require to wait for
             // extra responses
             if let ResponseBody::Nodes { total, ref nodes } = response.body {
@@ -1415,7 +1485,6 @@ impl Handler {
             {
                 warn!("Failed to inform of response {}", e)
             }
-            self.send_next_request::<P>(node_address).await;
         } else {
             // This is likely a late response and we have already failed the request. These get
             // dropped here.
@@ -1431,21 +1500,33 @@ impl Handler {
         self.active_requests.insert(node_address, request_call);
     }
 
-    /// Updates the session cache for a new session.
-    fn new_session(
+    /// Establishes a new session with a peer, or re-establishes an existing session if a
+    /// new challenge was issued during an ongoing session.
+    async fn new_session<P: ProtocolIdentity>(
         &mut self,
         node_address: NodeAddress,
         session: Session,
+        // Optional message nonce is required to filter out the request that was used in the
+        // handshake to re-establish a session, if applicable.
+        message_nonce: Option<MessageNonce>,
         enr_not_reachable: bool,
     ) {
         if let Some(current_session) = self.sessions.get_mut(&node_address) {
             current_session.update(session);
+            // If a session is re-established, due to a new handshake during an ongoing
+            // session, we need to replay any active requests from the prior session, excluding
+            // the request that was used to re-establish the session handshake.
+            self.replay_active_requests::<P>(&node_address, message_nonce)
+                .await;
         } else {
             self.sessions
-                .insert_raw(node_address, session, enr_not_reachable);
+                .insert_raw(node_address.clone(), session, enr_not_reachable);
             METRICS
                 .active_sessions
                 .store(self.sessions.len(), Ordering::Relaxed);
+            // We could have pending messages that were awaiting this session to be
+            // established. If so process them.
+            self.send_pending_requests::<P>(&node_address).await;
         }
     }
 
@@ -1498,7 +1579,7 @@ impl Handler {
             .await;
     }
 
-    /// Removes a session and updates associated metrics and fields.
+    /// Removes a session, fails all of that session's active & pending requests, and updates associated metrics and fields.
     async fn fail_session(
         &mut self,
         node_address: &NodeAddress,
@@ -1513,6 +1594,7 @@ impl Handler {
             // stop keeping hole punched for peer
             self.nat.untrack(&node_address.socket_addr);
         }
+        // fail all pending requests
         if let Some(to_remove) = self.pending_requests.remove(node_address) {
             for PendingRequest { request_id, .. } in to_remove {
                 match request_id {
@@ -1530,6 +1612,28 @@ impl Handler {
                     }
                 }
             }
+        }
+        // fail all active requests
+        for req in self
+            .active_requests
+            .remove_requests(node_address)
+            .unwrap_or_default()
+        {
+            match req.id() {
+                HandlerReqId::Internal(_) => {
+                    // Do not report failures on requests belonging to the handler.
+                }
+                HandlerReqId::External(id) => {
+                    if let Err(e) = self
+                        .service_send
+                        .send(HandlerOut::RequestFailed(id.clone(), error.clone()))
+                        .await
+                    {
+                        warn!("Failed to inform request failure {e}")
+                    }
+                }
+            }
+            self.remove_expected_response(node_address.socket_addr);
         }
     }
 
@@ -1561,6 +1665,21 @@ impl Handler {
             .write()
             .ban_nodes
             .retain(|_, time| time.is_none() || Some(Instant::now()) < *time);
+    }
+
+    /// Returns whether a session with this node does not exist and a request that initiates
+    /// a session has been sent.
+    fn is_awaiting_session_to_be_established(&mut self, node_address: &NodeAddress) -> bool {
+        if self.sessions.get(node_address).is_some() {
+            // session exists
+            return false;
+        }
+
+        if let Some(requests) = self.active_requests.get(node_address) {
+            requests.iter().any(|req| req.initiating_session())
+        } else {
+            false
+        }
     }
 
     async fn new_connection(
@@ -1613,7 +1732,7 @@ impl Handler {
     ) -> Result<(), NatError> {
         // Another hole punch process with this target may have just completed.
         if self.sessions.get(&target_node_address).is_some() {
-            return Err(NatError::Initiator(Discv5Error::SessionAlreadyEstablished(
+            return Err(NatError::Initiator(Error::SessionAlreadyEstablished(
                 target_node_address,
             )));
         }
@@ -1735,7 +1854,7 @@ impl Handler {
             // time out of the udp entrypoint for the target peer in the initiator's NAT, set by
             // the original timed out FINDNODE request from the initiator, as the initiator may
             // also be behind a NAT.
-            Err(NatError::Relay(Discv5Error::SessionNotEstablished))
+            Err(NatError::Relay(Error::SessionNotEstablished))
         }
     }
 

--- a/src/handler/nat.rs
+++ b/src/handler/nat.rs
@@ -96,7 +96,7 @@ impl Nat {
     }
 
     /// Called when a new observed address is reported at start up or after a
-    /// [`crate::Discv5Event::SocketUpdated`].
+    /// [`crate::Event::SocketUpdated`].
     pub fn set_is_behind_nat(
         &mut self,
         listen_sockets: &[SocketAddr],

--- a/src/handler/nat.rs
+++ b/src/handler/nat.rs
@@ -1,6 +1,6 @@
-use std::num::NonZeroUsize;
 use std::{
     net::{IpAddr, SocketAddr, UdpSocket},
+    num::NonZeroUsize,
     ops::RangeInclusive,
     time::Duration,
 };

--- a/src/handler/nat.rs
+++ b/src/handler/nat.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::{
     net::{IpAddr, SocketAddr, UdpSocket},
     ops::RangeInclusive,
@@ -49,7 +50,7 @@ impl Nat {
         ip_mode: IpMode,
         unused_port_range: Option<RangeInclusive<u16>>,
         ban_duration: Option<Duration>,
-        session_cache_capacity: usize,
+        session_cache_capacity: NonZeroUsize,
         unreachable_enr_limit: Option<usize>,
     ) -> Self {
         let mut nat = Nat {

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -85,7 +85,10 @@ async fn build_handler<P: ProtocolIdentity>(
         active_requests: ActiveRequests::new(config.request_timeout),
         pending_requests: HashMap::new(),
         filter_expected_responses,
-        sessions: LruTimeCache::new(config.session_timeout, Some(config.session_cache_capacity)),
+        sessions: LruTimeCache::new(
+            config.session_timeout,
+            Some(config.session_cache_capacity.get()),
+        ),
         one_time_sessions: LruTimeCache::new(
             Duration::from_secs(ONE_TIME_SESSION_TIMEOUT),
             Some(ONE_TIME_SESSION_CACHE_CAPACITY),

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -136,7 +136,7 @@ mod tests {
 
         fn test(&self) {
             let test_enr = {
-                let builder = &mut enr::EnrBuilder::new("v4");
+                let builder = &mut enr::Enr::builder();
                 if let Some(ip4) = self.enr_ip4 {
                     builder.ip4(ip4).udp4(IP4_TEST_PORT);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,70 +1,65 @@
-#![warn(rust_2018_idioms)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![allow(clippy::needless_doctest_main)]
 //! An implementation of [Discovery V5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md).
 //!
 //! # Overview
 //!
-//! Discovery v5 is a protocol designed for encrypted peer discovery and topic advertisement. Each peer/node
-//! on the network is identified via it's ENR ([Ethereum Name
+//! Discovery v5 is a protocol designed for encrypted peer discovery and topic advertisement. Each
+//! peer/node on the network is identified via it's ENR ([Ethereum Name
 //! Record](https://eips.ethereum.org/EIPS/eip-778)), which is essentially a signed key-value store
 //! containing the node's public key and optionally IP address and port.
 //!
-//! Discv5 employs a kademlia-like routing table to store and manage discovered peers (and topics tba). The
-//! protocol allows for external IP discovery in NAT environments through regular PING/PONG's with
+//! Discv5 employs a kademlia-like routing table to store and manage discovered peers. The protocol
+//! allows for external IP discovery in NAT environments through regular PING/PONG's with
 //! discovered nodes. Nodes return the external IP address that they have received and a simple
 //! majority is chosen as our external IP address. If an external IP address is updated, this is
-//! produced as an event to notify the swarm (if one is used for this behaviour).
+//! produced as an event.
 //!
-//!  For a simple CLI discovery service see [discv5-cli](https://github.com/AgeManning/discv5-cli)
+//! For a simple CLI discovery service see [discv5-cli](https://github.com/AgeManning/discv5-cli)
 //!
-//! This protocol is split into four main sections/layers:
+//! This protocol is split into four main layers:
 //!
-//!  * Socket - The [`socket`] module is responsible for opening the underlying UDP socket. It
-//!  creates individual tasks for sending/encoding and receiving/decoding packets from the UDP
-//!  socket.
-//!  * Handler - The protocol's communication is encrypted with `AES_GCM`. All node communication
-//!  undergoes a handshake, which results in a [`Session`]. [`Session`]'s are established when
-//!  needed and get dropped after a timeout. This section manages the creation and maintenance of
-//!  sessions between nodes and the encryption/decryption of packets from the socket. It is
-//!  realised by the [`handler::Handler`] struct and it runs in its own task.
-//!  * Service - This section contains the protocol-level logic. In particular it manages the
-//!  routing table of known ENR's, (and topic registration/advertisement tba) and performs
-//!  parallel queries for peer discovery. This section is realised by the [`Service`] struct. This
-//!  also runs in it's own thread.
-//!  * Application - This section is the user-facing API which can start/stop the underlying
-//!  tasks, initiate queries and obtain metrics about the underlying server.
+//! - [`socket`]: Responsible for opening the underlying UDP socket. It creates individual tasks
+//! for sending/encoding and receiving/decoding packets from the UDP socket.
+//! - [`handler`]: The protocol's communication is encrypted with `AES_GCM`. All node communication
+//! undergoes a handshake, which results in a `Session`. These are established when needed and get
+//! dropped after a timeout. The creation and maintenance of sessions between nodes and the
+//! encryption/decryption of packets from the socket is realised by the [`handler::Handler`] struct
+//! runnning in its own task.
+//! - [`service`]: Contains the protocol-level logic. The [`service::Service`] manages the routing
+//! table of known ENR's, and performs parallel queries for peer discovery. It also runs in it's
+//! own task.
+//! - [`Discv5`]: The application level. Manages the user-facing API. It starts/stops the underlying
+//! tasks, allows initiating queries and obtain metrics about the underlying server.
 //!
-//!  ## Event Stream
+//! ## Event Stream
 //!
-//!  The [`Discv5`] struct provides access to an event-stream which allows the user to listen to
-//!  [`Discv5Event`] that get generated from the underlying server. The stream can be obtained
-//!  from the [`Discv5::event_stream()`] function.
+//! The [`Discv5`] struct provides access to an event-stream which allows the user to listen to
+//! [`Event`] that get generated from the underlying server. The stream can be obtained from the
+//! [`Discv5::event_stream`] function.
 //!
-//!  ## Runtimes
+//! ## Runtimes
 //!
-//!  Discv5 requires a tokio runtime with timing and io enabled. An explicit runtime can be given
-//!  via the configuration. See the [`Discv5ConfigBuilder`] for further details. Such a runtime
-//!  must implement the [`Executor`] trait.
+//! Discv5 requires a tokio runtime with timing and io enabled. An explicit runtime can be given
+//! via the configuration. See the [`ConfigBuilder`] for further details. Such a runtime must
+//! implement the [`Executor`] trait.
 //!
-//!  If an explicit runtime is not provided via the configuration parameters, it is assumed that
-//!  a tokio runtime is present when creating the [`Discv5`] struct. The struct will use the
-//!  existing runtime for spawning the underlying server tasks. If a runtime is not present, the
-//!  creation of the [`Discv5`] struct will panic.
+//! If an explicit runtime is not provided via the configuration parameters, it is assumed that a
+//! tokio runtime is present when creating the [`Discv5`] struct. The struct will use the existing
+//! runtime for spawning the underlying server tasks. If a runtime is not present, the creation of
+//! the [`Discv5`] struct will panic.
 //!
 //! # Usage
 //!
 //! A simple example of creating this service is as follows:
 //!
 //! ```rust
-//!    use discv5::{enr, enr::{CombinedKey, NodeId}, TokioExecutor, Discv5, Discv5ConfigBuilder};
+//!    use discv5::{enr, enr::{CombinedKey, NodeId}, TokioExecutor, Discv5, ConfigBuilder};
 //!    use discv5::socket::ListenConfig;
 //!    use std::net::{Ipv4Addr, SocketAddr};
 //!
 //!    // construct a local ENR
 //!    let enr_key = CombinedKey::generate_secp256k1();
-//!    let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+//!    let enr = enr::Enr::empty(&enr_key).unwrap();
 //!
 //!    // build the tokio executor
 //!    let mut runtime = tokio::runtime::Builder::new_multi_thread()
@@ -80,7 +75,7 @@
 //!    };
 //!
 //!    // default configuration
-//!    let config = Discv5ConfigBuilder::new(listen_config).build();
+//!    let config = ConfigBuilder::new(listen_config).build();
 //!
 //!    // construct the discv5 server
 //!    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
@@ -98,14 +93,6 @@
 //!       println!("Found nodes: {:?}", found_nodes);
 //!    });
 //! ```
-//!
-//! [`Discv5`]: struct.Discv5.html
-//! [`Discv5Event`]: enum.Discv5Event.html
-//! [`Discv5Config`]: config/struct.Discv5Config.html
-//! [`Discv5ConfigBuilder`]: config/struct.Discv5ConfigBuilder.html
-//! [Packet]: packet/enum.Packet.html
-//! [`Service`]: service/struct.Service.html
-//! [`Session`]: session/struct.Session.html
 
 mod config;
 mod discv5;
@@ -129,9 +116,9 @@ extern crate lazy_static;
 
 pub type Enr = enr::Enr<enr::CombinedKey>;
 
-pub use crate::discv5::{Discv5, Discv5Event};
-pub use config::{Discv5Config, Discv5ConfigBuilder};
-pub use error::{Discv5Error, QueryError, RequestError, ResponseError};
+pub use crate::discv5::{Discv5, Event};
+pub use config::{Config, ConfigBuilder};
+pub use error::{Error, QueryError, RequestError, ResponseError};
 pub use executor::{Executor, TokioExecutor};
 pub use ipmode::IpMode;
 pub use kbucket::{ConnectionDirection, ConnectionState, Key};

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -5,9 +5,11 @@ use enr::{CombinedPublicKey, NodeId};
 use std::net::SocketAddr;
 
 #[cfg(feature = "libp2p")]
-use libp2p_core::{multiaddr::Protocol, Multiaddr};
-#[cfg(feature = "libp2p")]
-use libp2p_identity::{KeyType, PublicKey};
+use libp2p::{
+    identity::{KeyType, PublicKey},
+    multiaddr::Protocol,
+    Multiaddr,
+};
 
 /// This type relaxes the requirement of having an ENR to connect to a node, to allow for unsigned
 /// connection types, such as multiaddrs.

--- a/src/query_pool/peers/closest.rs
+++ b/src/query_pool/peers/closest.rs
@@ -23,7 +23,7 @@
 //
 use super::*;
 use crate::{
-    config::Discv5Config,
+    config::Config,
     kbucket::{Distance, Key, MAX_NODES_PER_BUCKET},
 };
 use std::{
@@ -76,7 +76,7 @@ pub struct FindNodeQueryConfig {
 }
 
 impl FindNodeQueryConfig {
-    pub fn new_from_config(config: &Discv5Config) -> Self {
+    pub fn new_from_config(config: &Config) -> Self {
         Self {
             parallelism: config.query_parallelism,
             num_results: MAX_NODES_PER_BUCKET,

--- a/src/query_pool/peers/predicate.rs
+++ b/src/query_pool/peers/predicate.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    config::Discv5Config,
+    config::Config,
     kbucket::{Distance, Key, PredicateKey, MAX_NODES_PER_BUCKET},
 };
 use std::{
@@ -55,7 +55,7 @@ pub(crate) struct PredicateQueryConfig {
 }
 
 impl PredicateQueryConfig {
-    pub(crate) fn new_from_config(config: &Discv5Config) -> Self {
+    pub(crate) fn new_from_config(config: &Config) -> Self {
         Self {
             parallelism: config.query_parallelism,
             num_results: MAX_NODES_PER_BUCKET,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -93,6 +93,15 @@ impl Message {
 
         let rlp = rlp::Rlp::new(data);
 
+        if rlp.item_count()? < 2 {
+            return Err(DecoderError::RlpIncorrectListLen);
+        }
+
+        let payload_info = rlp.payload_info()?;
+        if data.len() != payload_info.header_len + payload_info.value_len {
+            return Err(DecoderError::RlpInconsistentLengthAndData);
+        }
+
         match msg_type.try_into()? {
             MessageType::Ping | MessageType::FindNode | MessageType::TalkReq => {
                 Ok(Request::decode(msg_type, &rlp)?.into())

--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -2,10 +2,10 @@ use super::{MessageType, Payload, RequestBody, RequestId};
 use crate::Enr;
 use derive_more::Display;
 use rlp::{DecoderError, Rlp, RlpStream};
-use std::num::NonZeroU16;
 use std::{
     convert::TryInto,
     net::{IpAddr, Ipv6Addr},
+    num::NonZeroU16,
 };
 use tracing::debug;
 

--- a/src/socket/filter/mod.rs
+++ b/src/socket/filter/mod.rs
@@ -7,6 +7,7 @@ use lru::LruCache;
 use std::{
     collections::HashSet,
     net::{IpAddr, SocketAddr},
+    num::NonZeroUsize,
     sync::atomic::Ordering,
     time::{Duration, Instant},
 };
@@ -19,9 +20,16 @@ pub use config::FilterConfig;
 use rate_limiter::{LimitKind, RateLimiter};
 
 /// The maximum number of IPs to retain when calculating the number of nodes per IP.
-const KNOWN_ADDRS_SIZE: usize = 500;
+const KNOWN_ADDRS_SIZE: NonZeroUsize = match NonZeroUsize::new(500) {
+    Some(non_zero) => non_zero,
+    None => unreachable!(),
+};
 /// The number of IPs to retain at any given time that have banned nodes.
-const BANNED_NODES_SIZE: usize = 50;
+const BANNED_NODES_SIZE: NonZeroUsize = match NonZeroUsize::new(50) {
+    Some(non_zero) => non_zero,
+    None => unreachable!(),
+};
+
 /// The maximum number of packets to keep record of for metrics if the rate limiter is not
 /// specified.
 const DEFAULT_PACKETS_PER_SECOND: usize = 20;


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

Merge lastest `master` branch into `discv5.2`.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

I have updated the `Config::session_cache_capacity` type from usize to NonZeroUsize in 6d4fce2f05f51823021f971be41d4de379c313ad, for the following reasons:

- `Config::session_cache_capacity` is utilized in [Handler's session](https://github.com/ackintosh/discv5/blob/6d4fce2f05f51823021f971be41d4de379c313ad/src/handler/mod.rs#L332) (LruTimeCache) and in [`Nat::new_peer_latest_relay_cache`](https://github.com/ackintosh/discv5/blob/238dbc0d6d390f249157ce32027431577059efb9/src/handler/nat.rs#L59) (LruCache).
- The type of `Nat::new_peer_latest_relay_cache` is LruCache and the argument for `LruCache::new` is NonZeroUsize

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
