### PR TITLE
Fix buggy log message

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1453,8 +1453,7 @@ impl Service {
                             let node_id = active_request.contact.node_id();
                             let addr = active_request.contact.socket_addr();
                             let received = nodes_response.received_nodes.len();
-                            let expected = distances.len();
-                            warn!(%node_id, %addr, %error, %received, %expected, "FINDNODE request failed with partial results");
+                            warn!(%node_id, %addr, %error, %received, requested_distances=?distances, "FINDNODE request failed with partial results");
                             // if it's a query mark it as success, to process the partial
                             // collection of peers
                             self.discovered(


### PR DESCRIPTION
## Description

Fixes buggy log message. Log message was comparing the length of the list of requested distances with the list of received nodes. This pr instead prints the distance requested.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
