### PR TITLE
Downgrade some logs to make retention easier

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -310,7 +310,6 @@ impl Handler {
                     socket,
                     exit,
                 };
-                debug!("Handler Starting");
                 handler.start::<P>().await;
             }));
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -846,7 +846,7 @@ impl Handler {
                         .await;
                     } else {
                         // IP's or NodeAddress don't match. Drop the session.
-                        warn!(
+                        debug!(
                             "Session has invalid ENR. Enr sockets: {:?}, {:?}. Expected: {}",
                             enr.udp4_socket(),
                             enr.udp6_socket(),
@@ -906,7 +906,7 @@ impl Handler {
                 }
             }
         } else {
-            warn!(
+            debug!(
                 node_id = %node_address.node_id, addr = %node_address.socket_addr,
                 "Received an authenticated header without a matching WHOAREYOU request",
             );

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -251,18 +251,7 @@ impl std::fmt::Display for ResponseBody {
                 write!(f, "PONG: Enr-seq: {enr_seq}, Ip: {ip:?},  Port: {port}")
             }
             ResponseBody::Nodes { total, nodes } => {
-                write!(f, "NODES: total: {total}, Nodes: [")?;
-                let mut first = true;
-                for id in nodes {
-                    if !first {
-                        write!(f, ", {id}")?;
-                    } else {
-                        write!(f, "{id}")?;
-                    }
-                    first = false;
-                }
-
-                write!(f, "]")
+                write!(f, "NODES: total: {total}, Nodes: {}", nodes.len())
             }
             ResponseBody::Talk { response } => {
                 write!(f, "Response: Response {}", hex::encode(response))

--- a/src/service.rs
+++ b/src/service.rs
@@ -646,7 +646,7 @@ impl Service {
         let id = response.id.clone();
 
         if let Some(mut active_request) = self.active_requests.remove(&id) {
-            debug!(
+            trace!(
                 "Received RPC response: {} to request: {} from: {}",
                 response.body, active_request.request_body, active_request.contact
             );
@@ -734,7 +734,7 @@ impl Service {
                         let mut current_response =
                             self.active_nodes_responses.remove(&id).unwrap_or_default();
 
-                        debug!(
+                        trace!(
                             "Nodes Response: {} of {} received",
                             current_response.count, total
                         );
@@ -1161,7 +1161,7 @@ impl Service {
         };
         let contact = active_request.contact.clone();
 
-        debug!("Sending RPC {} to node: {}", request, contact);
+        trace!("Sending RPC {} to node: {}", request, contact);
         if self
             .handler_send
             .send(HandlerIn::Request(contact, Box::new(request)))
@@ -1304,7 +1304,7 @@ impl Service {
                     } => {
                         // The node was updated
                         if promoted_to_connected {
-                            debug!("Node promoted to connected: {}", node_id);
+                            trace!("Node promoted to connected: {}", node_id);
                             self.peers_to_ping.insert(node_id);
                         }
                     }
@@ -1329,7 +1329,7 @@ impl Service {
                         );
                     }
                     update => {
-                        debug!("Updated {:?}", update)
+                        trace!("Updated {:?}", update)
                     } // Updated ENR successfully.
                 }
             }

--- a/src/socket/send.rs
+++ b/src/socket/send.rs
@@ -52,7 +52,6 @@ impl SendHandler {
 
         // start the handler
         executor.spawn(Box::pin(async move {
-            debug!("Send handler starting");
             send_handler.start::<P>().await;
         }));
         (handler_send, exit_send)


### PR DESCRIPTION
## Description

Upstream libraries are now storing some of these logs. They can be quite verbose on a live network. This PR downgrades some of the logs to make them less noisy.
