### PR TITLE
fix: docs typo

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -656,7 +656,7 @@ impl<P: ProtocolIdentity> Discv5<P> {
 
     /// Starts a `FIND_NODE` request.
     ///
-    /// This will return less than or equal to `num_nodes` ENRs which satisfy the
+    /// This will return less than or equal to `target_peer_no` ENRs which satisfy the
     /// `predicate`.
     ///
     /// The predicate is a boxed function that takes an ENR reference and returns a boolean


### PR DESCRIPTION
small typo in docs comments