### PR TITLE
Pin ENR to the latest minor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.11.0", features = ["k256", "ed25519"] } 
+enr = { version = "0.11", features = ["k256", "ed25519"] } 
 tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
 libp2p = { version = "0.53", features = ["ed25519", "secp256k1"], optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }


### PR DESCRIPTION
A new patch version of ENR was released fixing a few bugs. 

This PR updates discv5 to tag the latest minor version so users get access to the patches.