### PR TITLE
Remove unused event `EnrAdded`

### DIFF
--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -193,7 +193,6 @@ async fn main() {
                 }
                 match discv5_ev {
                     Event::Discovered(enr) => info!("Enr discovered {}", enr),
-                    Event::EnrAdded { enr, replaced: _ } => info!("Enr added {}", enr),
                     Event::NodeInserted { node_id, replaced: _ } => info!("Node inserted {}", node_id),
                     Event::SessionEstablished(enr, _) => info!("Session established {}", enr),
                     Event::SocketUpdated(addr) => info!("Socket updated {}", addr),

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -60,8 +60,6 @@ pub enum Event {
     /// This happen spontaneously through queries as nodes return ENR's. These ENR's are not
     /// guaranteed to be live or contactable.
     Discovered(Enr),
-    /// A new ENR was added to the routing table.
-    EnrAdded { enr: Enr, replaced: Option<Enr> },
     /// A new node has been added to the routing table.
     NodeInserted {
         node_id: NodeId,


### PR DESCRIPTION
## Description

Removes unused events.

## Notes & open questions

Piggy-backing on https://github.com/sigp/discv5/pull/250 which introduces breaking changes.

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
