### PR TITLE
chore: slim deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.12", features = ["k256", "ed25519"] } 
+enr = { version = "0.12", features = ["k256", "ed25519"] }
 tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
-libp2p = { version = "0.53", features = ["ed25519", "secp256k1"], optional = true }
+libp2p-identity = { version = "0.2", features = [
+    "ed25519",
+    "secp256k1",
+], optional = true }
+multiaddr = { version = "0.18", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 futures = "0.3"
 uint = { version = "0.9", default-features = false }
@@ -48,5 +52,5 @@ tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-libp2p = ["dep:libp2p"]
+libp2p = ["dep:libp2p-identity", "dep:multiaddr"]
 serde = ["enr/serde"]

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -36,7 +36,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
 #[cfg(feature = "libp2p")]
-use libp2p::Multiaddr;
+use multiaddr::Multiaddr;
 
 // Create lazy static variable for the global permit/ban list
 use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,5 +126,11 @@ pub use packet::{DefaultProtocolId, ProtocolIdentity};
 pub use permit_ban::PermitBanList;
 pub use service::TalkRequest;
 pub use socket::{ListenConfig, RateLimiter, RateLimiterBuilder};
-// re-export the ENR crate
+// Re-export the ENR crate
 pub use enr;
+
+// Re-export libp2p-identity and multiaddr
+#[cfg(feature = "libp2p")]
+pub use libp2p_identity;
+#[cfg(feature = "libp2p")]
+pub use multiaddr;

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -4,11 +4,9 @@ use enr::{CombinedPublicKey, NodeId};
 use std::net::SocketAddr;
 
 #[cfg(feature = "libp2p")]
-use libp2p::{
-    identity::{KeyType, PublicKey},
-    multiaddr::Protocol,
-    Multiaddr,
-};
+use libp2p_identity::{KeyType, PublicKey};
+#[cfg(feature = "libp2p")]
+use multiaddr::{Multiaddr, Protocol};
 
 /// This type relaxes the requirement of having an ENR to connect to a node, to allow for unsigned
 /// connection types, such as multiaddrs.


### PR DESCRIPTION
## Description

Replaces `libp2p` with `libp2p-identity` and `multiaddr` which significantly lowers the amount of dependencies pulled in by the crate. Closes #253 

This PR also re-exports those two crates as they are needed to use some of the features introduced by the `libp2p` feature, so users end up adding the dependency in their tree manually on top. Closes #254 

## Notes & open questions

Both changes are in their own commits, so I can split it off into two PRs if needed

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
