### PR TITLE
chore(deps): replace libp2p dep with libp2p-identity and multiaddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ exclude = [".gitignore", ".github/*"]
 [dependencies]
 enr = { version = "0.12", features = ["k256", "ed25519"] } 
 tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
-libp2p = { version = "0.53", features = ["ed25519", "secp256k1"], optional = true }
+multiaddr = { version = "0.18", default-features = false, optional = true }
+libp2p-identity = {  version = "0.2", features = ["ed25519", "secp256k1"], optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 futures = "0.3"
 uint = { version = "0.9", default-features = false }
@@ -48,5 +49,5 @@ tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-libp2p = ["dep:libp2p"]
+libp2p = ["dep:multiaddr", "dep:libp2p-identity"]
 serde = ["enr/serde"]

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -36,7 +36,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
 #[cfg(feature = "libp2p")]
-use libp2p::Multiaddr;
+use multiaddr::Multiaddr;
 
 // Create lazy static variable for the global permit/ban list
 use crate::{

--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -4,11 +4,9 @@ use enr::{CombinedPublicKey, NodeId};
 use std::net::SocketAddr;
 
 #[cfg(feature = "libp2p")]
-use libp2p::{
-    identity::{KeyType, PublicKey},
-    multiaddr::Protocol,
-    Multiaddr,
-};
+use libp2p_identity::{KeyType, PublicKey};
+#[cfg(feature = "libp2p")]
+use multiaddr::{Multiaddr, Protocol};
 
 /// This type relaxes the requirement of having an ENR to connect to a node, to allow for unsigned
 /// connection types, such as multiaddrs.


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->
Closes #253

Reduces dependencies from 202 to 182 if libp2p feature is enabled by only importing required crates: `multiaddr` + `libp2p-identity` 

## Notes & open questions


<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
