### PR TITLE
Bump up actions/checkout version to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get latest version of stable rust
         run: rustup update stable
       - name: Check formatting with cargofmt
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get latest version of stable rust
         run: rustup update stable
       - name: Lint code for quality and style with Clippy
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get latest version of stable rust
         run: rustup update stable
       - name: Run tests in release
@@ -35,7 +35,7 @@ jobs:
       image: rust
     needs: cargo-fmt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get latest version of stable rust
         run: rustup update stable
       - name: Run tests in release
@@ -46,7 +46,7 @@ jobs:
     container:
       image: rust
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get latest version of stable rust
         run: rustup update stable
       - name: Check rustdoc links
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust nightly
       run: rustup toolchain install nightly
     - name: Install cargo-udeps


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

This PR gets rid of the warning displayed in actions:

https://github.com/sigp/discv5/actions/runs/10463483509?pr=261
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3.

<!-- ## Notes & open questions -->

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [ ] ~~Documentation updates if relevant~~
- [ ] ~~Tests if relevant~~
