### PR TITLE
More lenient ipv6 auto-update

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1552,7 +1552,7 @@ impl Service {
     /// class.
     ///
     /// If we are in dual-stack mode and don't have enough votes for either ipv4 or ipv6 and the
-    /// requesting node/vote is what we need, then this will return true
+    /// requesting node/vote is what we need, then this will return true.
     fn require_more_ip_votes(&mut self, is_ipv6: bool) -> bool {
         if !matches!(self.ip_mode, IpMode::DualStack) {
             return false;

--- a/src/service.rs
+++ b/src/service.rs
@@ -1566,7 +1566,7 @@ impl Service {
                     ((None, Some(_)), false) |
                     // We don't have enough ipv6 votes, but this is an IPv6 node.
                     ((Some(_), None), true) |
-                    // We don't have enough ipv6 or ipv4 nodes, ping this peer
+                    // We don't have enough ipv6 or ipv4 nodes, ping this peer.
                     ((None, None), _,) => true,
                     // We have enough votes do nothing.
                     ((_, _), _,) =>  false,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1551,7 +1551,7 @@ impl Service {
     /// Helper function that determines if we need more votes for a specific IP
     /// class.
     ///
-    /// If we are in dual-stack made and don't have enough votes for either ipv4 or ipv6 and the
+    /// If we are in dual-stack mode and don't have enough votes for either ipv4 or ipv6 and the
     /// requesting node/vote is what we need, then this will return true
     fn require_more_ip_votes(&mut self, is_ipv6: bool) -> bool {
         if !matches!(self.ip_mode, IpMode::DualStack) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1548,7 +1548,7 @@ impl Service {
         }
     }
 
-    /// This is a helper function that determines if we need more votes for a specific IP
+    /// Helper function that determines if we need more votes for a specific IP
     /// class.
     ///
     /// If we are in dual-stack made and don't have enough votes for either ipv4 or ipv6 and the

--- a/src/service.rs
+++ b/src/service.rs
@@ -1558,7 +1558,9 @@ impl Service {
             return false;
         }
 
-        if let Some(ip_votes) = self.ip_votes.as_mut() {
+       let Some(ip_votes) = self.ip_votes.as_mut() else {
+           return false;
+       }
             match (ip_votes.majority(), is_ipv6) {
                     // We don't have enough ipv4 votes, but this is an IPv4-only node.
                     ((None, Some(_)), false) |

--- a/src/service.rs
+++ b/src/service.rs
@@ -1566,7 +1566,7 @@ impl Service {
                     ((Some(_), None), true) |
                     // We don't have enough ipv6 or ipv4 nodes, ping this peer
                     ((None, None), _,) => true,
-                    // We have enough votes do nothing
+                    // We have enough votes do nothing.
                     ((_, _), _,) =>  false,
                 }
         } else {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1562,7 +1562,7 @@ impl Service {
             match (ip_votes.majority(), is_ipv6) {
                     // We don't have enough ipv4 votes, but this is an IPv4-only node.
                     ((None, Some(_)), false) |
-                    // We don't have enough ipv6 votes, but this is an IPv6 node
+                    // We don't have enough ipv6 votes, but this is an IPv6 node.
                     ((Some(_), None), true) |
                     // We don't have enough ipv6 or ipv4 nodes, ping this peer
                     ((None, None), _,) => true,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1558,10 +1558,10 @@ impl Service {
             return false;
         }
 
-       let Some(ip_votes) = self.ip_votes.as_mut() else {
-           return false;
-       }
-            match (ip_votes.majority(), is_ipv6) {
+        let Some(ip_votes) = self.ip_votes.as_mut() else {
+            return false;
+        };
+        match (ip_votes.majority(), is_ipv6) {
                     // We don't have enough ipv4 votes, but this is an IPv4-only node.
                     ((None, Some(_)), false) |
                     // We don't have enough ipv6 votes, but this is an IPv6 node.
@@ -1570,10 +1570,7 @@ impl Service {
                     ((None, None), _,) => true,
                     // We have enough votes do nothing.
                     ((_, _), _,) =>  false,
-                }
-        } else {
-            false
-        }
+            }
     }
 
     /// A future that maintains the routing table and inserts nodes when required. This returns the

--- a/src/service.rs
+++ b/src/service.rs
@@ -1356,9 +1356,9 @@ impl Service {
                             if let Some(ip_votes) = self.ip_votes.as_mut() {
                                 match (ip_votes.majority(), enr.udp4_socket(), enr.udp6_socket()) {
                                     // We don't have enough ipv4 votes, but this is an IPv4 node.
-                                    ((None, Some(_)), Some(_), _) |
+                                    ((Some(_), None), Some(_), _) |
                                     // We don't have enough ipv6 votes, but this is an IPv6 node
-                                    ((Some(_), None), _, Some(_)) |
+                                    ((None, Some(_)), _, Some(_)) |
                                     // We don't have enough ipv6 or ipv4 nodes, ping this peer
                                     ((None, None), _, _) => self.send_ping(enr, None),
                                     // We have enough votes do nothing

--- a/src/service.rs
+++ b/src/service.rs
@@ -1356,7 +1356,7 @@ impl Service {
                             if let Some(ip_votes) = self.ip_votes.as_mut() {
                                 match (ip_votes.majority(), enr.udp4_socket(), enr.udp6_socket()) {
                                     // We don't have enough ipv4 votes, but this is an IPv4 node.
-                                    ((None, Some(_)), Some(_), _) | 
+                                    ((None, Some(_)), Some(_), _) |
                                     // We don't have enough ipv6 votes, but this is an IPv6 node
                                     ((Some(_), None), _, Some(_)) |
                                     // We don't have enough ipv6 or ipv4 nodes, ping this peer

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -458,7 +458,7 @@ async fn test_ipv6_update_amongst_ipv4_dominated_network() {
         false,
     );
 
-    // Load up the routing table with 100 random ENRs
+    // Load up the routing table with 100 random ENRs.
 
     for _ in 0..100 {
         let key = CombinedKey::generate_secp256k1();

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -18,9 +18,17 @@ use crate::{
 use enr::CombinedKey;
 use parking_lot::RwLock;
 use rand;
-use std::{collections::HashMap, net::Ipv4Addr, net::Ipv6Addr, sync::Arc, time::Duration};
-use tokio::sync::mpsc::{Sender, UnboundedReceiver};
-use tokio::sync::{mpsc, oneshot};
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, Ipv6Addr},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::sync::{
+    mpsc,
+    mpsc::{Sender, UnboundedReceiver},
+    oneshot,
+};
 
 /// Default UDP port number to use for tests requiring UDP exposure
 pub const DEFAULT_UDP_PORT: u16 = 0;

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -487,7 +487,7 @@ async fn test_ipv6_update_amongst_ipv4_dominated_network() {
         service.inject_session_established(enr.clone(), direction);
     }
 
-    // Collect all the messages to the handler and count the PING requests for ENR v6 addresses
+    // Collect all the messages to the handler and count the PING requests for ENR v6 addresses.
     let mut v6_pings = 0;
     while let Ok(event) = handler_recv.try_recv() {
         if let HandlerIn::Request(contact, request) = event {

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -123,7 +123,7 @@ fn build_non_handler_service(
     };
     let config = ConfigBuilder::new(listen_config).build();
 
-    // Fake's the handler with empty channels
+    // Fake's the handler with empty channels.
     let (handler_send, handler_recv_fake) = mpsc::unbounded_channel();
     let (handler_send_fake, handler_recv) = mpsc::channel(1000);
 

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -146,7 +146,7 @@ fn build_non_handler_service(
 
     let ip_vote = IpVote::new(10, Duration::from_secs(10000));
 
-    // create the required channels
+    // create the required channels.
     let (_discv5_send, discv5_recv) = mpsc::channel(30);
     let (_exit_send, exit) = oneshot::channel();
 

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -491,15 +491,12 @@ async fn test_ipv6_update_amongst_ipv4_dominated_network() {
     // Collect all the messages to the handler and count the PING requests for ENR v6 addresses
     let mut v6_pings = 0;
     while let Ok(event) = handler_recv.try_recv() {
-        match event {
-            HandlerIn::Request(contact, request) => {
-                if contact.node_address().socket_addr.is_ipv6()
-                    && matches!(request.body, RequestBody::Ping { .. })
-                {
-                    v6_pings += 1
-                }
+        if let HandlerIn::Request(contact, request) = event {
+            if contact.node_address().socket_addr.is_ipv6()
+                && matches!(request.body, RequestBody::Ping { .. })
+            {
+                v6_pings += 1
             }
-            _ => {}
         }
     }
 

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -112,7 +112,7 @@ async fn build_service<P: ProtocolIdentity>(
     }
 }
 
-fn build_non_handler_service<P: ProtocolIdentity>(
+fn build_non_handler_service(
     local_enr: Arc<RwLock<Enr>>,
     enr_key: Arc<RwLock<CombinedKey>>,
     filters: bool,
@@ -452,12 +452,11 @@ async fn test_ipv6_update_amongst_ipv4_dominated_network() {
         .build(&enr_key)
         .unwrap();
 
-    let (mut service, mut handler_recv, _handler_send) =
-        build_non_handler_service::<DefaultProtocolId>(
-            Arc::new(RwLock::new(local_enr)),
-            Arc::new(RwLock::new(enr_key)),
-            false,
-        );
+    let (mut service, mut handler_recv, _handler_send) = build_non_handler_service(
+        Arc::new(RwLock::new(local_enr)),
+        Arc::new(RwLock::new(enr_key)),
+        false,
+    );
 
     // Load up the routing table with 100 random ENRs
 


### PR DESCRIPTION
## Description

On IPv4 dominated networks, local routing tables can be fully populated with ipv4 nodes limiting the number of ipv6 ping/pong responses. This can prevent the enr-auto-update from finding and updating a node's ENR to its external socket. 

For security reasons, we can't just accept PONG responses from any node on the network. For this reason, we only ping peers that make it into our routing table as a number of security measures must be passed for a node to enter the table. However if the table is full, we reject peers from entering and therefore do not attempt to PING them. 

This PR suggests the following mechanism:
If a peer fails to make it into the routing table, and we are lacking votes on either IPv4 or IPv6 and this peer can add a vote AND they are an outgoing peer (i.e one that we have chosen to connect to, for security reasons) then we ping them to get an extra vote for our external address. 
