### PR TITLE
Increase default vote duration to 2 minutes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -161,7 +161,7 @@ impl ConfigBuilder {
     }
 
     /// The interval over which votes are remembered when determining our external IP. A lower
-    /// interval will respond faster to IP changes. Default is 30 seconds.
+    /// interval will respond faster to IP changes. Default is 2 minutes.
     pub fn vote_duration(&mut self, vote_duration: Duration) -> &mut Self {
         self.config.vote_duration = vote_duration;
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub request_timeout: Duration,
 
     /// The interval over which votes are remembered when determining our external IP. A lower
-    /// interval will respond faster to IP changes. Default is 30 seconds.
+    /// interval will respond faster to IP changes. Default is 2 minutes.
     pub vote_duration: Duration,
 
     /// The timeout after which a `QueryPeer` in an ongoing query is marked unresponsive.
@@ -121,7 +121,7 @@ impl ConfigBuilder {
         let config = Config {
             enable_packet_filter: false,
             request_timeout: Duration::from_secs(1),
-            vote_duration: Duration::from_secs(30),
+            vote_duration: Duration::from_secs(120),
             query_peer_timeout: Duration::from_secs(2),
             query_timeout: Duration::from_secs(60),
             request_retries: 1,


### PR DESCRIPTION
I have been looking into complications with low ipv6 peers in real world networks. 

Originally this default was set, to handle ip changes more rapidly, however with low ipv6 peers on networks this becomes a hindering factor. 

Although it is configurable, the default should be large enough to accommodate real-world networks. 

I think this might have been originally set when we ping'd every connection. As no longer do that, maintaining pong votes for 2 minutes seems to be a reasonable tradeoff. 