### PR TITLE
Automatic Firewall/NAT Detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,14 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { version = "0.12", features = ["k256", "ed25519"] }
+enr = { git = "https://github.com/sigp/enr", branch = "remove-fields", features = [
+  "k256",
+  "ed25519",
+] } # enr = { version = "0.12", features = ["k256", "ed25519"] }
 tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
 libp2p-identity = { version = "0.2", features = [
-    "ed25519",
-    "secp256k1",
+  "ed25519",
+  "secp256k1",
 ], optional = true }
 multiaddr = { version = "0.18", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -318,8 +318,11 @@ impl ConfigBuilder {
     /// connection in this duration, we revoke our ENR address advertisement for 6 hours, before
     /// trying again. This can be set to None, to always advertise and never revoke. The default is
     /// Some(10 minutes).
-    pub fn auto_nat_listen_duration(&mut self, auto_nat_listen_duration: Option<Duration>) -> &mut Self {
-        self.config.auto_nat_listen_duration = auto_nat_listen_duration
+    pub fn auto_nat_listen_duration(
+        &mut self,
+        auto_nat_listen_duration: Option<Duration>,
+    ) -> &mut Self {
+        self.config.auto_nat_listen_duration = auto_nat_listen_duration;
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,14 +94,14 @@ pub struct Config {
 
     /// Auto-discovering our IP address, is only one part in discovering our NAT/firewall
     /// situation. We need to determine if we are behind a firewall that is preventing incoming
-    /// connections (this is espcially true for IPv6 where all connections will report the same
+    /// connections (this is especially true for IPv6 where all connections will report the same
     /// external IP). To do this, Discv5 uses a heuristic, which is that after we set an address in
     /// our ENR, we wait for this duration to see if we have any incoming connections. If we
     /// receive a single INCOMING connection in this duration, we consider ourselves contactable,
     /// until we update or change our IP address again. If we fail to receive an incoming
     /// connection in this duration, we revoke our ENR address advertisement for 6 hours, before
     /// trying again. This can be set to None, to always advertise and never revoke. The default is
-    /// Some(10 minutes).
+    /// Some(5 minutes).
     pub auto_nat_listen_duration: Option<Duration>,
 
     /// A custom executor which can spawn the discv5 tasks. This must be a tokio runtime, with
@@ -153,7 +153,7 @@ impl ConfigBuilder {
             filter_max_bans_per_ip: Some(5),
             permit_ban_list: PermitBanList::default(),
             ban_duration: Some(Duration::from_secs(3600)), // 1 hour
-            auto_nat_listen_duration: Some(Duration::from_secs(600)), // 10 minutes
+            auto_nat_listen_duration: Some(Duration::from_secs(300)), // 5 minutes
             executor: None,
             listen_config,
         };
@@ -310,14 +310,14 @@ impl ConfigBuilder {
 
     /// Auto-discovering our IP address, is only one part in discovering our NAT/firewall
     /// situation. We need to determine if we are behind a firewall that is preventing incoming
-    /// connections (this is espcially true for IPv6 where all connections will report the same
+    /// connections (this is especially true for IPv6 where all connections will report the same
     /// external IP). To do this, Discv5 uses a heuristic, which is that after we set an address in
     /// our ENR, we wait for this duration to see if we have any incoming connections. If we
     /// receive a single INCOMING connection in this duration, we consider ourselves contactable,
     /// until we update or change our IP address again. If we fail to receive an incoming
     /// connection in this duration, we revoke our ENR address advertisement for 6 hours, before
     /// trying again. This can be set to None, to always advertise and never revoke. The default is
-    /// Some(10 minutes).
+    /// Some(5 minutes).
     pub fn auto_nat_listen_duration(
         &mut self,
         auto_nat_listen_duration: Option<Duration>,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 lazy_static! {
     pub static ref METRICS: InternalMetrics = InternalMetrics::default();
@@ -16,6 +16,10 @@ pub struct InternalMetrics {
     pub bytes_sent: AtomicUsize,
     /// The number of bytes received.
     pub bytes_recv: AtomicUsize,
+    /// Whether we consider ourselves contactable or not on ipv4.
+    pub ipv4_contactable: AtomicBool,
+    /// Whether we consider ourselves contactable or not on ipv6.
+    pub ipv6_contactable: AtomicBool,
 }
 
 impl Default for InternalMetrics {
@@ -26,6 +30,8 @@ impl Default for InternalMetrics {
             unsolicited_requests_per_window: AtomicUsize::new(0),
             bytes_sent: AtomicUsize::new(0),
             bytes_recv: AtomicUsize::new(0),
+            ipv4_contactable: AtomicBool::new(false),
+            ipv6_contactable: AtomicBool::new(false),
         }
     }
 }
@@ -55,6 +61,10 @@ pub struct Metrics {
     pub bytes_sent: usize,
     /// The number of bytes received.
     pub bytes_recv: usize,
+    /// Whether we consider ourselves contactable or not.
+    pub ipv4_contactable: bool,
+    /// Whether we consider ourselves contactable or not.
+    pub ipv6_contactable: bool,
 }
 
 impl From<&METRICS> for Metrics {
@@ -67,6 +77,8 @@ impl From<&METRICS> for Metrics {
                 / internal_metrics.moving_window as f64,
             bytes_sent: internal_metrics.bytes_sent.load(Ordering::Relaxed),
             bytes_recv: internal_metrics.bytes_recv.load(Ordering::Relaxed),
+            ipv4_contactable: internal_metrics.ipv4_contactable.load(Ordering::Relaxed),
+            ipv6_contactable: internal_metrics.ipv6_contactable.load(Ordering::Relaxed),
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -31,6 +31,7 @@ use crate::{
     },
     rpc, Config, Enr, Event, IpMode,
 };
+use connectivity_state::DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT;
 use connectivity_state::{ConnectivityState, TimerFailure};
 use delay_map::HashSetDelay;
 use enr::{CombinedKey, NodeId};
@@ -469,7 +470,7 @@ impl Service {
                         TimerFailure::V4 => {
                             // We have not received enough incoming connections in the required
                             // time. Remove our ENR advertisement.
-                            info!(ip_version="v4", next_attempt=?self.connectivity_state.ipv4_next_connectivity_test, "UDP Socket removed from ENR");
+                            info!(ip_version="v4", next_attempt_in=%DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT.as_secs(), "UDP Socket removed from ENR");
                             if let Err(error) = self.local_enr.write().remove_udp_socket(&self.enr_key.read()) {
                                 error!(?error, "Failed to update the ENR");
                             }
@@ -477,7 +478,7 @@ impl Service {
                         TimerFailure::V6 => {
                             // We have not received enough incoming connections in the required
                             // time. Remove our ENR advertisement.
-                            info!(ip_version="v6", next_attempt=?self.connectivity_state.ipv6_next_connectivity_test, "UDP Socket removed from ENR");
+                            info!(ip_version="v6", next_attempt_in=%DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT.as_secs(), "UDP Socket removed from ENR");
                             if let Err(error) = self.local_enr.write().remove_udp6_socket(&self.enr_key.read()) {
                                 error!(?error, "Failed to update the ENR");
                             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -31,6 +31,7 @@ use crate::{
     },
     rpc, Config, Enr, Event, IpMode,
 };
+use connectivity_state::ConnectivityState;
 use delay_map::HashSetDelay;
 use enr::{CombinedKey, NodeId};
 use fnv::FnvHashMap;
@@ -49,6 +50,7 @@ use std::{
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, trace, warn};
 
+mod connectivity_state;
 mod ip_vote;
 mod query_info;
 mod test;
@@ -170,52 +172,41 @@ use crate::discv5::PERMIT_BAN_LIST;
 pub struct Service {
     /// Configuration parameters.
     config: Config,
-
     /// The local ENR of the server.
     local_enr: Arc<RwLock<Enr>>,
-
     /// The key associated with the local ENR.
     enr_key: Arc<RwLock<CombinedKey>>,
-
     /// Storage of the ENR record for each node.
     kbuckets: Arc<RwLock<KBucketsTable<NodeId, Enr>>>,
-
     /// All the iterative queries we are currently performing.
     queries: QueryPool<QueryInfo, NodeId, Enr>,
-
     /// RPC requests that have been sent and are awaiting a response. Some requests are linked to a
     /// query.
     active_requests: FnvHashMap<RequestId, ActiveRequest>,
-
     /// Keeps track of the number of responses received from a NODES response.
     active_nodes_responses: HashMap<RequestId, NodesResponse>,
-
     /// A map of votes nodes have made about our external IP address. We accept the majority.
     ip_votes: Option<IpVote>,
-
     /// The channel to send messages to the handler.
     handler_send: mpsc::UnboundedSender<HandlerIn>,
-
     /// The channel to receive messages from the handler.
     handler_recv: mpsc::Receiver<HandlerOut>,
-
     /// The exit channel to shutdown the handler.
     handler_exit: Option<oneshot::Sender<()>>,
-
     /// The channel of messages sent by the controlling discv5 wrapper.
     discv5_recv: mpsc::Receiver<ServiceRequest>,
-
     /// The exit channel for the service.
     exit: oneshot::Receiver<()>,
-
     /// A queue of peers that require regular ping to check connectivity.
     peers_to_ping: HashSetDelay<NodeId>,
-
     /// A channel that the service emits events on.
     event_stream: Option<mpsc::Sender<Event>>,
-
-    // Type of socket we are using
+    /// Type of socket we are using
     ip_mode: IpMode,
+    /// This stores information about whether we think we have open ports and if we are externally
+    /// contactable or not. This decides if we should update our ENR or set it to None, if we are
+    /// not contactable.
+    connectivity_state: ConnectivityState,
 }
 
 /// Active RPC request awaiting a response from the handler.
@@ -300,6 +291,8 @@ impl Service {
         let (discv5_send, discv5_recv) = mpsc::channel(30);
         let (exit_send, exit) = oneshot::channel();
 
+        let connectivity_state = ConnectivityState::new(config.auto_nat_listen_duration);
+
         config
             .executor
             .clone()
@@ -322,6 +315,7 @@ impl Service {
                     exit,
                     config: config.clone(),
                     ip_mode,
+                    connectivity_state,
                 };
 
                 info!(mode = ?service.ip_mode, "Discv5 Service started");
@@ -656,276 +650,278 @@ impl Service {
         // verify we know of the rpc_id
         let id = response.id.clone();
 
-        if let Some(mut active_request) = self.active_requests.remove(&id) {
-            debug!(
-                response = %response.body,
-                request = %active_request.request_body,
-                from = %active_request.contact,
-                "Received RPC response",
+        let Some(mut active_request) = self.active_requests.remove(&id) else {
+            warn!(%id, "Received an RPC response which doesn't match a request");
+            return;
+        };
+
+        debug!(
+            response = %response.body,
+            request = %active_request.request_body,
+            from = %active_request.contact,
+            "Received RPC response",
+        );
+        // Check that the responder matches the expected request
+
+        let expected_node_address = active_request.contact.node_address();
+        if expected_node_address != node_address {
+            debug_unreachable!("Handler returned a response not matching the used socket addr");
+            return error!(
+                expected = %expected_node_address,
+                received = %node_address,
+                request_id = %id,
+                "Received a response from an unexpected address",
             );
+        }
 
-            // Check that the responder matches the expected request
+        if !response.match_request(&active_request.request_body) {
+            warn!(
+                %node_address,
+                "Node gave an incorrect response type. Ignoring response"
+            );
+            return;
+        }
 
-            let expected_node_address = active_request.contact.node_address();
-            if expected_node_address != node_address {
-                debug_unreachable!("Handler returned a response not matching the used socket addr");
-                return error!(
-                    expected = %expected_node_address,
-                    received = %node_address,
-                    request_id = %id,
-                    "Received a response from an unexpected address",
-                );
-            }
+        let node_id = node_address.node_id;
 
-            if !response.match_request(&active_request.request_body) {
-                warn!(
-                    %node_address,
-                    "Node gave an incorrect response type. Ignoring response"
-                );
-                return;
-            }
+        match response.body {
+            ResponseBody::Nodes { total, mut nodes } => {
+                if total > MAX_NODES_RESPONSES as u64 {
+                    warn!(
+                        total,
+                        "NodesResponse has a total larger than {}, nodes will be truncated",
+                        MAX_NODES_RESPONSES
+                    );
+                }
 
-            let node_id = node_address.node_id;
+                // These are sanitized and ordered
+                let distances_requested = match &active_request.request_body {
+                    RequestBody::FindNode { distances } => distances,
+                    _ => unreachable!(),
+                };
 
-            match response.body {
-                ResponseBody::Nodes { total, mut nodes } => {
-                    if total > MAX_NODES_RESPONSES as u64 {
-                        warn!(
-                            total,
-                            "NodesResponse has a total larger than {}, nodes will be truncated",
-                            MAX_NODES_RESPONSES
-                        );
+                if let Some(CallbackResponse::Nodes(callback)) = active_request.callback.take() {
+                    if let Err(e) = callback.send(Ok(nodes)) {
+                        warn!(error = ?e, "Failed to send response in callback")
                     }
+                    return;
+                }
 
-                    // These are sanitized and ordered
-                    let distances_requested = match &active_request.request_body {
-                        RequestBody::FindNode { distances } => distances,
-                        _ => unreachable!(),
-                    };
+                // Filter out any nodes that are not of the correct distance
+                let peer_key: kbucket::Key<NodeId> = node_id.into();
 
-                    if let Some(CallbackResponse::Nodes(callback)) = active_request.callback.take()
+                // The distances we send are sanitized an ordered.
+                // We never send an ENR request in combination of other requests.
+                if distances_requested.len() == 1 && distances_requested[0] == 0 {
+                    // we requested an ENR update
+                    if nodes.len() > 1 {
+                        warn!(
+                            %node_address,
+                            "Peer returned more than one ENR for itself. Blacklisting",
+                        );
+                        let ban_timeout = self.config.ban_duration.map(|v| Instant::now() + v);
+                        PERMIT_BAN_LIST.write().ban(node_address, ban_timeout);
+                        nodes.retain(|enr| peer_key.log2_distance(&enr.node_id().into()).is_none());
+                    }
+                } else {
+                    let before_len = nodes.len();
+                    nodes.retain(|enr| {
+                        peer_key
+                            .log2_distance(&enr.node_id().into())
+                            .map(|distance| distances_requested.contains(&distance))
+                            .unwrap_or_else(|| false)
+                    });
+
+                    if nodes.len() < before_len {
+                        // Peer sent invalid ENRs. Blacklist the Node
+                        let node_id = active_request.contact.node_id();
+                        let addr = active_request.contact.socket_addr();
+                        warn!(%node_id, %addr, "ENRs received of unsolicited distances. Blacklisting");
+                        let ban_timeout = self.config.ban_duration.map(|v| Instant::now() + v);
+                        PERMIT_BAN_LIST.write().ban(node_address, ban_timeout);
+                    }
+                }
+
+                // handle the case that there is more than one response
+                if total > 1 {
+                    let mut current_response =
+                        self.active_nodes_responses.remove(&id).unwrap_or_default();
+
+                    debug!(
+                        "Nodes Response: {} of {} received",
+                        current_response.count, total
+                    );
+                    // If there are more requests coming, store the nodes and wait for
+                    // another response
+                    // If we have already received all our required nodes, drop any extra
+                    // rpc messages.
+                    if current_response.received_nodes.len() < self.config.max_nodes_response
+                        && (current_response.count as u64) < total
+                        && current_response.count < MAX_NODES_RESPONSES
                     {
-                        if let Err(e) = callback.send(Ok(nodes)) {
-                            warn!(error = ?e, "Failed to send response in callback")
-                        }
+                        current_response.count += 1;
+
+                        current_response.received_nodes.append(&mut nodes);
+                        self.active_nodes_responses
+                            .insert(id.clone(), current_response);
+                        self.active_requests.insert(id, active_request);
                         return;
                     }
 
-                    // Filter out any nodes that are not of the correct distance
-                    let peer_key: kbucket::Key<NodeId> = node_id.into();
-
-                    // The distances we send are sanitized an ordered.
-                    // We never send an ENR request in combination of other requests.
-                    if distances_requested.len() == 1 && distances_requested[0] == 0 {
-                        // we requested an ENR update
-                        if nodes.len() > 1 {
-                            warn!(
-                                %node_address,
-                                "Peer returned more than one ENR for itself. Blacklisting",
-                            );
-                            let ban_timeout = self.config.ban_duration.map(|v| Instant::now() + v);
-                            PERMIT_BAN_LIST.write().ban(node_address, ban_timeout);
-                            nodes.retain(|enr| {
-                                peer_key.log2_distance(&enr.node_id().into()).is_none()
-                            });
-                        }
-                    } else {
-                        let before_len = nodes.len();
-                        nodes.retain(|enr| {
-                            peer_key
-                                .log2_distance(&enr.node_id().into())
-                                .map(|distance| distances_requested.contains(&distance))
-                                .unwrap_or_else(|| false)
-                        });
-
-                        if nodes.len() < before_len {
-                            // Peer sent invalid ENRs. Blacklist the Node
-                            let node_id = active_request.contact.node_id();
-                            let addr = active_request.contact.socket_addr();
-                            warn!(%node_id, %addr, "ENRs received of unsolicited distances. Blacklisting");
-                            let ban_timeout = self.config.ban_duration.map(|v| Instant::now() + v);
-                            PERMIT_BAN_LIST.write().ban(node_address, ban_timeout);
-                        }
-                    }
-
-                    // handle the case that there is more than one response
-                    if total > 1 {
-                        let mut current_response =
-                            self.active_nodes_responses.remove(&id).unwrap_or_default();
-
-                        debug!(
-                            "Nodes Response: {} of {} received",
-                            current_response.count, total
-                        );
-                        // If there are more requests coming, store the nodes and wait for
-                        // another response
-                        // If we have already received all our required nodes, drop any extra
-                        // rpc messages.
-                        if current_response.received_nodes.len() < self.config.max_nodes_response
-                            && (current_response.count as u64) < total
-                            && current_response.count < MAX_NODES_RESPONSES
-                        {
-                            current_response.count += 1;
-
-                            current_response.received_nodes.append(&mut nodes);
-                            self.active_nodes_responses
-                                .insert(id.clone(), current_response);
-                            self.active_requests.insert(id, active_request);
-                            return;
-                        }
-
-                        // have received all the Nodes responses we are willing to accept
-                        // ignore duplicates here as they will be handled when adding
-                        // to the DHT
-                        current_response.received_nodes.append(&mut nodes);
-                        nodes = current_response.received_nodes;
-                    }
-
-                    debug!(
-                        len = nodes.len(),
-                        total,
-                        from = %active_request.contact,
-                        "Received a nodes response",
-                    );
-                    // note: If a peer sends an initial NODES response with a total > 1 then
-                    // in a later response sends a response with a total of 1, all previous nodes
-                    // will be ignored.
-                    // ensure any mapping is removed in this rare case
-                    self.active_nodes_responses.remove(&id);
-
-                    self.discovered(&node_id, nodes, active_request.query_id);
+                    // have received all the Nodes responses we are willing to accept
+                    // ignore duplicates here as they will be handled when adding
+                    // to the DHT
+                    current_response.received_nodes.append(&mut nodes);
+                    nodes = current_response.received_nodes;
                 }
-                ResponseBody::Pong { enr_seq, ip, port } => {
-                    // Send the response to the user, if they are who asked
-                    if let Some(CallbackResponse::Pong(callback)) = active_request.callback {
-                        let response = Pong {
-                            enr_seq,
-                            ip,
-                            port: port.get(),
+
+                debug!(
+                    len = nodes.len(),
+                    total,
+                    from = %active_request.contact,
+                    "Received a nodes response",
+                );
+                // note: If a peer sends an initial NODES response with a total > 1 then
+                // in a later response sends a response with a total of 1, all previous nodes
+                // will be ignored.
+                // ensure any mapping is removed in this rare case
+                self.active_nodes_responses.remove(&id);
+
+                self.discovered(&node_id, nodes, active_request.query_id);
+            }
+            ResponseBody::Pong { enr_seq, ip, port } => {
+                // Send the response to the user, if they are who asked
+                if let Some(CallbackResponse::Pong(callback)) = active_request.callback {
+                    let response = Pong {
+                        enr_seq,
+                        ip,
+                        port: port.get(),
+                    };
+                    if let Err(e) = callback.send(Ok(response)) {
+                        warn!(error = ?e, "Failed to send callback response")
+                    };
+                    return;
+                }
+
+                let socket = SocketAddr::new(ip, port.get());
+                // Register the vote, this counts towards potentially updating the ENR for external
+                // advertisement
+                self.handle_ip_vote_from_pong(node_id, socket);
+
+                // check if we need to request a new ENR
+                if let Some(enr) = self.find_enr(&node_id) {
+                    if enr.seq() < enr_seq {
+                        // request an ENR update
+                        debug!(from = %active_request.contact, "Requesting an ENR update");
+                        let request_body = RequestBody::FindNode { distances: vec![0] };
+                        let active_request = ActiveRequest {
+                            contact: active_request.contact,
+                            request_body,
+                            query_id: None,
+                            callback: None,
                         };
+                        self.send_rpc_request(active_request);
+                    }
+                    // Only update the routing table if the new ENR is contactable
+                    if self.ip_mode.get_contactable_addr(&enr).is_some() {
+                        self.connection_updated(node_id, ConnectionStatus::PongReceived(enr));
+                    }
+                }
+            }
+            ResponseBody::Talk { response } => {
+                // Send the response to the user
+                match active_request.callback {
+                    Some(CallbackResponse::Talk(callback)) => {
                         if let Err(e) = callback.send(Ok(response)) {
                             warn!(error = ?e, "Failed to send callback response")
                         };
-                    } else {
-                        let socket = SocketAddr::new(ip, port.get());
-                        // perform ENR majority-based update if required.
+                    }
+                    _ => error!("Invalid callback for response"),
+                }
+            }
+        }
+    }
 
-                        // Only count votes that from peers we have contacted.
-                        let key: kbucket::Key<NodeId> = node_id.into();
-                        let should_count = matches!(
+    // We have received a PONG which informs us for our external socket. This function decides
+    // how we should handle this vote and whether or not to update our ENR. This is done on a
+    // majority-based voting system, see `IpVote` for more details.
+    fn handle_ip_vote_from_pong(&mut self, node_id: NodeId, socket: SocketAddr) {
+        // Only count votes that are from peers we have contacted.
+        let key: kbucket::Key<NodeId> = node_id.into();
+        let should_count = matches!(
                         self.kbuckets.write().entry(&key),
                         kbucket::Entry::Present(_, status)
                             if status.is_connected() && !status.is_incoming());
 
-                        if should_count | self.require_more_ip_votes(socket.is_ipv6()) {
-                            // get the advertised local addresses
-                            let (local_ip4_socket, local_ip6_socket) = {
-                                let local_enr = self.local_enr.read();
-                                (local_enr.udp4_socket(), local_enr.udp6_socket())
-                            };
+        if should_count | self.require_more_ip_votes(socket.is_ipv6()) {
+            // get the advertised local addresses
+            let (local_ip4_socket, local_ip6_socket) = {
+                let local_enr = self.local_enr.read();
+                (local_enr.udp4_socket(), local_enr.udp6_socket())
+            };
 
-                            if let Some(ref mut ip_votes) = self.ip_votes {
-                                ip_votes.insert(node_id, socket);
-                                let (maybe_ip4_majority, maybe_ip6_majority) = ip_votes.majority();
+            if let Some(ref mut ip_votes) = self.ip_votes {
+                ip_votes.insert(node_id, socket);
+                let (maybe_ip4_majority, maybe_ip6_majority) = ip_votes.majority();
 
-                                let new_ip4 = maybe_ip4_majority.and_then(|majority| {
-                                    if Some(majority) != local_ip4_socket {
-                                        Some(majority)
-                                    } else {
-                                        None
-                                    }
-                                });
-                                let new_ip6 = maybe_ip6_majority.and_then(|majority| {
-                                    if Some(majority) != local_ip6_socket {
-                                        Some(majority)
-                                    } else {
-                                        None
-                                    }
-                                });
+                let new_ip4 = maybe_ip4_majority.and_then(|majority| {
+                    if Some(majority) != local_ip4_socket {
+                        Some(majority)
+                    } else {
+                        None
+                    }
+                });
+                let new_ip6 = maybe_ip6_majority.and_then(|majority| {
+                    if Some(majority) != local_ip6_socket {
+                        Some(majority)
+                    } else {
+                        None
+                    }
+                });
 
-                                if new_ip4.is_some() || new_ip6.is_some() {
-                                    let mut updated = false;
+                if new_ip4.is_some() || new_ip6.is_some() {
+                    let mut updated = false;
 
-                                    // Check if our advertised IPV6 address needs to be updated.
-                                    if let Some(new_ip6) = new_ip6 {
-                                        let new_ip6: SocketAddr = new_ip6.into();
-                                        let result = self
-                                            .local_enr
-                                            .write()
-                                            .set_udp_socket(new_ip6, &self.enr_key.read());
-                                        match result {
-                                            Ok(_) => {
-                                                updated = true;
-                                                info!(%new_ip6, "Local UDP ip6 socket updated");
-                                                self.send_event(Event::SocketUpdated(new_ip6));
-                                            }
-                                            Err(e) => {
-                                                warn!(ip6 = %new_ip6, error = ?e, "Failed to update local UDP ip6 socket.");
-                                            }
-                                        }
-                                    }
-                                    if let Some(new_ip4) = new_ip4 {
-                                        let new_ip4: SocketAddr = new_ip4.into();
-                                        let result = self
-                                            .local_enr
-                                            .write()
-                                            .set_udp_socket(new_ip4, &self.enr_key.read());
-                                        match result {
-                                            Ok(_) => {
-                                                updated = true;
-                                                info!(%new_ip4, "Local UDP socket updated");
-                                                self.send_event(Event::SocketUpdated(new_ip4));
-                                            }
-                                            Err(e) => {
-                                                warn!(ip = %new_ip4, error = ?e, "Failed to update local UDP socket.");
-                                            }
-                                        }
-                                    }
-                                    if updated {
-                                        self.ping_connected_peers();
-                                    }
-                                }
+                    // Check if our advertised IPV6 address needs to be updated.
+                    if let Some(new_ip6) = new_ip6 {
+                        let new_ip6: SocketAddr = new_ip6.into();
+                        let result = self
+                            .local_enr
+                            .write()
+                            .set_udp_socket(new_ip6, &self.enr_key.read());
+                        match result {
+                            Ok(_) => {
+                                updated = true;
+                                info!(%new_ip6, "Local UDP ip6 socket updated");
+                                self.send_event(Event::SocketUpdated(new_ip6));
                             }
-                        }
-
-                        // check if we need to request a new ENR
-                        if let Some(enr) = self.find_enr(&node_id) {
-                            if enr.seq() < enr_seq {
-                                // request an ENR update
-                                debug!(from = %active_request.contact, "Requesting an ENR update");
-                                let request_body = RequestBody::FindNode { distances: vec![0] };
-                                let active_request = ActiveRequest {
-                                    contact: active_request.contact,
-                                    request_body,
-                                    query_id: None,
-                                    callback: None,
-                                };
-                                self.send_rpc_request(active_request);
-                            }
-                            // Only update the routing table if the new ENR is contactable
-                            if self.ip_mode.get_contactable_addr(&enr).is_some() {
-                                self.connection_updated(
-                                    node_id,
-                                    ConnectionStatus::PongReceived(enr),
-                                );
+                            Err(e) => {
+                                warn!(ip6 = %new_ip6, error = ?e, "Failed to update local UDP ip6 socket.");
                             }
                         }
                     }
-                }
-                ResponseBody::Talk { response } => {
-                    // Send the response to the user
-                    match active_request.callback {
-                        Some(CallbackResponse::Talk(callback)) => {
-                            if let Err(e) = callback.send(Ok(response)) {
-                                warn!(error = ?e, "Failed to send callback response")
-                            };
+                    if let Some(new_ip4) = new_ip4 {
+                        let new_ip4: SocketAddr = new_ip4.into();
+                        let result = self
+                            .local_enr
+                            .write()
+                            .set_udp_socket(new_ip4, &self.enr_key.read());
+                        match result {
+                            Ok(_) => {
+                                updated = true;
+                                info!(%new_ip4, "Local UDP socket updated");
+                                self.send_event(Event::SocketUpdated(new_ip4));
+                            }
+                            Err(e) => {
+                                warn!(ip = %new_ip4, error = ?e, "Failed to update local UDP socket.");
+                            }
                         }
-                        _ => error!("Invalid callback for response"),
+                    }
+                    if updated {
+                        self.ping_connected_peers();
                     }
                 }
             }
-        } else {
-            warn!(%id, "Received an RPC response which doesn't match a request");
         }
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -31,8 +31,9 @@ use crate::{
     },
     rpc, Config, Enr, Event, IpMode,
 };
-use connectivity_state::DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT;
-use connectivity_state::{ConnectivityState, TimerFailure};
+use connectivity_state::{
+    ConnectivityState, TimerFailure, DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT,
+};
 use delay_map::HashSetDelay;
 use enr::{CombinedKey, NodeId};
 use fnv::FnvHashMap;

--- a/src/service/connectivity_state.rs
+++ b/src/service/connectivity_state.rs
@@ -24,7 +24,8 @@ use std::pin::Pin;
 use std::time::{Duration, Instant};
 use tokio::time::{sleep, Sleep};
 
-const DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT: Duration = Duration::from_secs(21600); // 6 hours
+// const DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT: Duration = Duration::from_secs(21600); // 6 hours
+pub const DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT: Duration = Duration::from_secs(100);
 
 /// The error returned from polling the ConnectivityState indicating whether IPv4 or IPv6 has
 /// failed a connectivity check.

--- a/src/service/connectivity_state.rs
+++ b/src/service/connectivity_state.rs
@@ -18,12 +18,16 @@
 //! this time, which prevents our ENR from being updated.
 
 use crate::metrics::METRICS;
-use futures::future::{pending, Either};
-use futures::FutureExt;
-use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use futures::{
+    future::{pending, Either},
+    FutureExt,
+};
+use std::{
+    net::SocketAddr,
+    pin::Pin,
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
 use tokio::time::{sleep, Sleep};
 use tracing::info;
 

--- a/src/service/connectivity_state.rs
+++ b/src/service/connectivity_state.rs
@@ -1,0 +1,40 @@
+//! This keeps track of our whether we should advertise an external IP address or not based on
+//! whether we think we are externally contactable or not.
+//!
+//! We determine this by advertising our discovered IP address, if we receive inbound connections,
+//! then we know we are externally contactable. If we see nothing for a period of time, we consider
+//! ourselves non-contactable and revoke our advertised IP address. We wait for
+//! DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT before trying again.
+
+use std::time::{Duration, Instant};
+
+const DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT: Duration = Duration::from_secs(21600); // 6 hours
+
+pub(crate) struct ConnectivityState {
+    /// Whether we consider ourselves externally contactable or not.
+    contactable: bool,
+    /// The duration we will wait for incoming connections before deciding if we are contactable or
+    /// not. If this is None, we consider ourselves always contactable.
+    duration_for_incoming_connections: Option<Duration>,
+    /// If we are awaiting for incoming connections, this is the instant that we stop waiting.
+    ipv4_incoming_wait_time: Option<Instant>,
+    /// If we are awaiting for incoming connections, this is the instant that we stop waiting.
+    ipv6_incoming_wait_time: Option<Instant>,
+    /// The time that we being checking connectivity tests for ipv4.
+    ipv4_next_connectivity_test: Instant,
+    /// The time that we being checking connectivity tests for ipv6.
+    ipv6_next_connectivity_test: Instant,
+}
+
+impl ConnectivityState {
+    pub fn new(duration_for_incoming_connections: Option<Duration>) -> Self {
+        ConnectivityState {
+            contactable: false,
+            duration_for_incoming_connections,
+            ipv4_incoming_wait_time: None,
+            ipv6_incoming_wait_time: None,
+            ipv4_next_connectivity_test: Instant::now(),
+            ipv6_next_connectivity_test: Instant::now(),
+        }
+    }
+}

--- a/src/service/connectivity_state.rs
+++ b/src/service/connectivity_state.rs
@@ -11,11 +11,11 @@
 //! 1. Our ENR socket gets updated
 //! 2. This triggers us to set an incoming wait timer
 //! 3. a. If we receive an incoming connection within this time, we consider ourselves contactable
-//! and we remove the timer.
+//!     and we remove the timer.
 //! 3. b. If we don't receive a connection and the timer expires. If the timer expires, we set our
-//! external ENR address to None and set the `next_connectivity_test` to
-//! DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT in the future. This will prevent counting votes until
-//! this time, which prevents our ENR from being updated.
+//!     external ENR address to None and set the `next_connectivity_test` to
+//!     DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT in the future. This will prevent counting votes until
+//!     this time, which prevents our ENR from being updated.
 
 use crate::metrics::METRICS;
 use futures::{

--- a/src/service/connectivity_state.rs
+++ b/src/service/connectivity_state.rs
@@ -5,36 +5,126 @@
 //! then we know we are externally contactable. If we see nothing for a period of time, we consider
 //! ourselves non-contactable and revoke our advertised IP address. We wait for
 //! DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT before trying again.
+//!
+//!
+//! The process works via the following:
+//! 1. Our ENR socket gets updated
+//! 2. This triggers us to set an incoming wait timer
+//! 3a. If we receive an incoming connection within this time, we consider ourselves contactable
+//! and we remove the timer.
+//! 3b. If we don't receive a connection and the timer expires. If the timer expires, we set our
+//! external ENR address to None and set the `next_connectivity_test` to
+//! DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT in the future. This will prevent counting votes until
+//! this time, which prevents our ENR from being updated.
 
+use futures::future::{pending, Either};
+use futures::FutureExt;
+use std::net::SocketAddr;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
+use tokio::time::{sleep, Sleep};
 
 const DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT: Duration = Duration::from_secs(21600); // 6 hours
 
+/// The error returned from polling the ConnectivityState indicating whether IPv4 or IPv6 has
+/// failed a connectivity check.
+pub enum TimerFailure {
+    /// IPv4 Timer failure
+    V4,
+    /// IPv6 Timer failure
+    V6,
+}
+
 pub(crate) struct ConnectivityState {
-    /// Whether we consider ourselves externally contactable or not.
-    contactable: bool,
     /// The duration we will wait for incoming connections before deciding if we are contactable or
     /// not. If this is None, we consider ourselves always contactable.
     duration_for_incoming_connections: Option<Duration>,
     /// If we are awaiting for incoming connections, this is the instant that we stop waiting.
-    ipv4_incoming_wait_time: Option<Instant>,
+    ipv4_incoming_wait_time: Option<Pin<Box<Sleep>>>,
     /// If we are awaiting for incoming connections, this is the instant that we stop waiting.
-    ipv6_incoming_wait_time: Option<Instant>,
-    /// The time that we being checking connectivity tests for ipv4.
-    ipv4_next_connectivity_test: Instant,
-    /// The time that we being checking connectivity tests for ipv6.
-    ipv6_next_connectivity_test: Instant,
+    ipv6_incoming_wait_time: Option<Pin<Box<Sleep>>>,
+    /// The time that we begin checking connectivity tests for ipv4.
+    pub ipv4_next_connectivity_test: Instant,
+    /// The time that we begin checking connectivity tests for ipv6.
+    pub ipv6_next_connectivity_test: Instant,
 }
 
 impl ConnectivityState {
     pub fn new(duration_for_incoming_connections: Option<Duration>) -> Self {
         ConnectivityState {
-            contactable: false,
             duration_for_incoming_connections,
             ipv4_incoming_wait_time: None,
             ipv6_incoming_wait_time: None,
             ipv4_next_connectivity_test: Instant::now(),
             ipv6_next_connectivity_test: Instant::now(),
+        }
+    }
+
+    /// Checks if we are in a state to handle new IP votes. If we are waiting to do a connectivity
+    /// test for this specific ip kind, this returns false.
+    pub fn should_count_ip_vote(&self, socket: &SocketAddr) -> bool {
+        // If this configuration is not set, we just accept all votes and disable this
+        // functionality.
+        if self.duration_for_incoming_connections.is_none() {
+            return true;
+        }
+
+        // If we have failed a connectivity test, then we wait until the next duration window
+        // before counting new votes.
+        match socket {
+            SocketAddr::V4(_) => Instant::now() >= self.ipv4_next_connectivity_test,
+            SocketAddr::V6(_) => Instant::now() >= self.ipv6_next_connectivity_test,
+        }
+    }
+
+    /// We have updated our external ENR socket. If enabled (i.e duration_for_incoming_connections
+    /// is not None) then we start a timer to await for any kind of incoming connection. This will
+    /// verify that we are contactable. If we receive nothing in `duration_for_incoming_connections` then we consider ourselves non-contactable
+    pub fn enr_socket_update(&mut self, socket: &SocketAddr) {
+        if let Some(duration_to_wait) = self.duration_for_incoming_connections.clone() {
+            match socket {
+                SocketAddr::V4(_) => {
+                    self.ipv4_incoming_wait_time = Some(Box::pin(sleep(duration_to_wait)))
+                }
+                SocketAddr::V6(_) => {
+                    self.ipv6_incoming_wait_time = Some(Box::pin(sleep(duration_to_wait)))
+                }
+            }
+        }
+    }
+
+    // We have received an incoming connection. If we were awaiting for a connection, we remove the
+    // expiry timer and we are done. The ENR will remain advertised and new votes will still count
+    // to potentially change the IP address if a legitimate change occurs.
+    pub fn received_incoming_connection(&mut self, socket: &SocketAddr) {
+        match socket {
+            SocketAddr::V4(_) => self.ipv4_incoming_wait_time = None,
+            SocketAddr::V6(_) => self.ipv6_incoming_wait_time = None,
+        }
+    }
+
+    pub async fn poll(&mut self) -> TimerFailure {
+        match (
+            self.ipv4_incoming_wait_time.as_mut(),
+            self.ipv6_incoming_wait_time.as_mut(),
+        ) {
+            (Some(ipv4_sleep), Some(ipv6_sleep)) => {
+                match futures::future::select(ipv4_sleep, ipv6_sleep).await {
+                    Either::Left(_) => {
+                        self.ipv4_next_connectivity_test =
+                            Instant::now() + DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT;
+                        TimerFailure::V4
+                    }
+                    Either::Right(_) => {
+                        self.ipv6_next_connectivity_test =
+                            Instant::now() + DURATION_UNTIL_NEXT_CONNECTIVITY_ATTEMPT;
+                        TimerFailure::V6
+                    }
+                }
+            }
+            (Some(ipv4_sleep), None) => ipv4_sleep.map(|_| TimerFailure::V4).await,
+            (None, Some(ipv6_sleep)) => ipv6_sleep.map(|_| TimerFailure::V6).await,
+            (None, None) => pending().await,
         }
     }
 }


### PR DESCRIPTION
## Description

Symmetric NATs and IPv6 are currently a pain point in discovery. Discv5 has a mechanism to discover its external IP and port (`socket` from now on). We use a majority voting system based on `PONG` responses. 

The problem is that full-cone NATs can be included in the IP address discovery. Furthermore, with ipv6, all connections are likely not NAT'd and the external IP discovery is going to return our IPv6 address. 

Currently we are assuming that if our external address is discoverable, that we are contactable (as we get discovered when a correct port forward is established in ipv4). However this will generally not be the case for full-cone NATs and IPv6. In fact, if we default to dual-stack, all ipv6 nodes will update their ENR to their ipv6 address, rendering them non-contactable (as ipv6 is the default connection for ipv6-compatible nodes) if their firewall still prevents ipv6 traffic. 

We therefore need a way to determine if we are contactable or not to avoid incorrectly advertising our ipv6 or ipv4 discovered addresses. 

This PR proposes the following:
1. We discover our external IP addresses as usual (ipv6 will likely always be discovered)
2. We advertise our discovered address as usual
3. We wait a period of time for inbound connections
4. If we do not see any inbound connections, we assume we are not contactable and remove our IP advertisement from our ENR and then wait an extended period of time (6 hours) before attempting again
5. If we do see inbound connections, consider ourselves contactable and leave our ENR advertising our address, until we discover a new external ip address (as usual)


I have done some preliminary testing on this PR and it seems to function as I expect. 

However with these added complexity more eyes are always helpful :)
