### PR TITLE
Prevent dual-stack spamming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
-version = "0.8.0"
+version = "0.9.0"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "Apache-2.0"
 repository = "https://github.com/sigp/discv5"
@@ -12,10 +12,7 @@ categories = ["network-programming", "asynchronous"]
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-enr = { git = "https://github.com/sigp/enr", branch = "remove-fields", features = [
-  "k256",
-  "ed25519",
-] } # enr = { version = "0.12", features = ["k256", "ed25519"] }
+enr = { version = "0.13.0", features = [ "k256", "ed25519", ] } # enr = { version = "0.12", features = ["k256", "ed25519"] }
 tokio = { version = "1", features = ["net", "sync", "macros", "rt"] }
 libp2p-identity = { version = "0.2", features = [
   "ed25519",
@@ -25,7 +22,7 @@ multiaddr = { version = "0.18", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 futures = "0.3"
 uint = { version = "0.10", default-features = false }
-alloy-rlp = { version = "0.3.8", default-features = true }
+alloy-rlp = { version = "0.3", default-features = true }
 # This version must be kept up to date do it uses the same dependencies as ENR
 hkdf = "0.12"
 hex = "0.4"
@@ -36,8 +33,8 @@ socket2 = "0.5"
 smallvec = "1"
 parking_lot = "0.12"
 lazy_static = "1"
-aes = "0.8.4"
-ctr = "0.9.2"
+aes = "0.8"
+ctr = "0.9"
 aes-gcm = "0.10.3"
 tracing = { version = "0.1", features = ["log"] }
 lru = "0.12"

--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -410,9 +410,7 @@ where
             // Adjust `first_connected_pos` accordingly.
             match old_status.state {
                 ConnectionState::Connected => {
-                    if self.first_connected_pos.map_or(false, |p| p == pos.0)
-                        && pos.0 == self.nodes.len()
-                    {
+                    if self.first_connected_pos == Some(pos.0) && pos.0 == self.nodes.len() {
                         // It was the last connected node.
                         self.first_connected_pos = None
                     }

--- a/src/service/ip_vote.rs
+++ b/src/service/ip_vote.rs
@@ -131,7 +131,8 @@ mod tests {
         votes.insert(NodeId::random(), socket_3);
         votes.insert(NodeId::random(), socket_3);
 
-        assert_eq!(votes.majority(), (Some(socket_2), None));
+        // Assert that in a draw situation a majority is still chosen.
+        assert!(votes.majority().0.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Description

I've been testing Ipv6 and dual stack support. 

There was a bug, where in dual-stack mode, if a router has not SNAT'd correctly they use random source ports. The `majority()` voting system will never reach a majority and we will continue to ping all peers we see. 

We waste a lot of traffic as we are never going to reach a majority in this scenario. The correct logic is not to check for a majority on a specific port before asking more more PING's rather, if we have enough PONG responses to reach a majority if our NAT was correctly set up, then no longer send more PINGs. 

This PR updates to this new logic. 
