### PR TITLE
Fix encode TalkRequest regression during library transition

### DIFF
--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -410,9 +410,7 @@ where
             // Adjust `first_connected_pos` accordingly.
             match old_status.state {
                 ConnectionState::Connected => {
-                    if self.first_connected_pos.map_or(false, |p| p == pos.0)
-                        && pos.0 == self.nodes.len()
-                    {
+                    if (self.first_connected_pos == Some(pos.0)) && pos.0 == self.nodes.len() {
                         // It was the last connected node.
                         self.first_connected_pos = None
                     }


### PR DESCRIPTION
## Description

Well updating from the old rlp library to the new one alloy_rlp there was a regression for encoding/decoding TalkRequests, which is required for the Portal Network.

I noticed something was broken when trying to upgrade Trin to alloy back in Apr 5, 2024. I delayed upgrading https://github.com/ethereum/trin/pull/1231 because I didn't have time to debug this issue at the time.

So here is the fix to the regression and a few tests to prevent it from happening again 

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [ ] Documentation updates if relevant
- [x] Tests if relevant
