### PR TITLE
perf: don't derive node_id from signature unless required

### DIFF
--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -27,7 +27,10 @@ pub struct NonContactable {
 
 impl NodeContact {
     pub fn node_id(&self) -> NodeId {
-        self.public_key.clone().into()
+        match self.enr {
+            Some(ref enr) => enr.node_id(),
+            None => self.public_key.clone().into(),
+        }
     }
 
     pub fn seq_no(&self) -> Option<u64> {


### PR DESCRIPTION
## Description

Every time we send a talk_request `node_address()` is called which calls `node_id()`

```
   pub fn node_id(&self) -> NodeId {
        self.public_key.clone().into()
    }
```

Hence every time we send a TalkRequest we are deriving the node_id from `self.public_key.clone().into()`  the signature which is very computationally expensive, especially as we are sending metric tons of talk requests

If the Enr is already present we don't need to re-derive the node_id so if it is present just use the node_id already derived

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

@AgeManning @jxs @ackintosh ping for review
