### PR TITLE
perf: use NodeContact instead of Enr for sending talk_req()

### DIFF
--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -267,6 +267,10 @@ impl<P: ProtocolIdentity> Discv5<P> {
         nodes_to_send
     }
 
+    pub fn ip_mode(&self) -> IpMode {
+        self.ip_mode
+    }
+
     /// Mark a node in the routing table as `Disconnected`.
     ///
     /// A `Disconnected` node will be present in the routing table and will be only
@@ -568,10 +572,10 @@ impl<P: ProtocolIdentity> Discv5<P> {
         }
     }
 
-    /// Request a TALK message from a node, identified via the ENR.
+    /// Request a TALK message from a node, identified via the NodeContact.
     pub fn talk_req(
         &self,
-        enr: Enr,
+        node_contact: NodeContact,
         protocol: Vec<u8>,
         request: Vec<u8>,
     ) -> impl Future<Output = Result<Vec<u8>, RequestError>> + 'static {
@@ -579,10 +583,8 @@ impl<P: ProtocolIdentity> Discv5<P> {
 
         let (callback_send, callback_recv) = oneshot::channel();
         let channel = self.clone_channel();
-        let ip_mode = self.ip_mode;
 
         async move {
-            let node_contact = NodeContact::try_from_enr(enr, ip_mode)?;
             let channel = channel.map_err(|_| RequestError::ServiceNotStarted)?;
 
             let event = ServiceRequest::Talk(node_contact, protocol, request, callback_send);


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

```rust
    pub fn try_from_enr(enr: Enr, ip_mode: IpMode) -> Result<Self, NonContactable> {
        let socket_addr = match ip_mode.get_contactable_addr(&enr) {
            Some(socket_addr) => socket_addr,
            None => return Err(NonContactable { enr }),
        };

        Ok(NodeContact {
            public_key: enr.public_key(),
            socket_addr,
            enr: Some(enr),
        })
    }
```

Every time we were sending a talk request we were converting the `Enr` to `NodeContact`. In doing this operation we call `public_key()` or in other terms we are recovering the public key every time we send a talk request, in Portal we send all our messages over TalkRequests, currently `public_key()` is taking over 8.7% of the samples I get from running my benchmark https://github.com/ethereum/trin/pull/1660, by reusing the NodeContact we can avoid repetitively recovering the public key every time

In the benchmark I am sending 6.7GB of block history, so 8.7 percent is fairly significant

![image](https://github.com/user-attachments/assets/8d446456-3c12-41c1-9766-123ad47ef6eb)


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->


@jxs @AgeManning @ackintosh ping for review