### PR TITLE
Add constructor for NodeContact

### DIFF
--- a/src/node_info.rs
+++ b/src/node_info.rs
@@ -26,6 +26,14 @@ pub struct NonContactable {
 }
 
 impl NodeContact {
+    pub fn new(public_key: CombinedPublicKey, socket_addr: SocketAddr, enr: Option<Enr>) -> Self {
+        NodeContact {
+            public_key,
+            socket_addr,
+            enr,
+        }
+    }
+
     pub fn node_id(&self) -> NodeId {
         self.public_key.clone().into()
     }


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

I want to be able to construct the NodeContact object myself. As I want to impl From<X> for NodeContact {} in our codebase, since for us Enr will always be present so having it behind a option is inconvenient 

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [ ] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant

@jxs @AgeManning @ackintosh ping for review