### PR TITLE
Version bump to v0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
-version = "0.10.0"
+version = "0.10.1"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "Apache-2.0"
 repository = "https://github.com/sigp/discv5"


### PR DESCRIPTION
## Description

Bumps to version 0.10.1 - This is to handle a bug in RLP encoding larger ENRs. 
