### PR TITLE
Remove unnecessary k-bucket lookups

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -861,7 +861,7 @@ impl Service {
                     }
                     // Only update the routing table if the new ENR is contactable
                     if self.ip_mode.get_contactable_addr(&enr).is_some() {
-                        self.connection_updated(node_id, ConnectionStatus::PongReceived(enr));
+                        self.connection_updated(node_id, ConnectionStatus::PongReceived);
                     }
                 }
             }
@@ -1410,19 +1410,19 @@ impl Service {
                     }
                 }
             }
-            ConnectionStatus::PongReceived(enr) => {
-                match self
-                    .kbuckets
-                    .write()
-                    .update_node(&key, enr, Some(ConnectionState::Connected))
-                {
+            ConnectionStatus::PongReceived => {
+                match self.kbuckets.write().update_node_status(
+                    &key,
+                    ConnectionState::Connected,
+                    None,
+                ) {
                     UpdateResult::Failed(reason) => {
                         self.peers_to_ping.remove(&node_id);
-                        debug!(node = %node_id, ?reason, "Could not update ENR from pong");
+                        debug!(node = %node_id, ?reason, "Could not update connection status from pong");
                     }
                     update => {
-                        debug!(update_result = ?update, "ENR has been updated based on the pong")
-                    } // Updated ENR successfully.
+                        trace!(update_result = ?update, "Peer's conenction status has been updated based on the pong")
+                    }
                 }
             }
             ConnectionStatus::Disconnected => {
@@ -1698,7 +1698,7 @@ enum ConnectionStatus {
     /// A node has started a new connection with us.
     Connected(Enr, ConnectionDirection),
     /// We received a Pong from a new node. Do not have the connection direction.
-    PongReceived(Enr),
+    PongReceived,
     /// The node has disconnected
     Disconnected,
 }


### PR DESCRIPTION
## Description

Look for bug I found this pointless lookup. 

On pong responses we seem to get the ENR from our buckets then attempt to update our buckets with that same ENR. Its a pointless and illogical process. The main intent was just to update the status of the node. 

I've simplified the code to perform what it was meant to do, just update the status of the node as being connected when we receive a pong. 
