### PR TITLE
Remove ping optimization

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -929,7 +929,6 @@ impl Service {
                                 self.connectivity_state.enr_socket_update(&new_ip4);
                                 info!(ip_version="v4", %new_ip4, "Local UDP socket updated");
                                 self.send_event(Event::SocketUpdated(new_ip4));
-                                self.ping_connected_peers();
                             }
                             Err(e) => {
                                 warn!(ip = %new_ip4, error = ?e, "Failed to update local UDP socket.");
@@ -964,7 +963,6 @@ impl Service {
                                 self.connectivity_state.enr_socket_update(&new_ip6);
                                 info!(ip_version="v6", %new_ip6, "Local UDP socket updated");
                                 self.send_event(Event::SocketUpdated(new_ip6));
-                                self.ping_connected_peers();
                             }
                             Err(e) => {
                                 warn!(ip6 = %new_ip6, error = ?e, "Failed to update local UDP ip6 socket.");


### PR DESCRIPTION
## Description

The PING mechanism for discv5 informs our peers of ENR updates as the sequence number is included with the PING. We ping every connected peer by default every 5 minutes (not all at once, each peer has a 5 minute timer). 

Once we have decided that our ENR should be updated (given the PONG's from our peers have aligned on a fixed value) we have been sending out PINGs to all our peers to inform them to update our ENR. This is an optimization that allows us to quickly form connections and get our ENR into the routing table of other peers as soon as we know we are externally contactable. 

We are investigating an issue, whereby a non-stable decision as to our external address can lead to ping amplifications. If we think this is likely to happen, it probably isn't worth this optimization, also sending these excessive pings is quite noisey and probably its fine to wait for the natural 5 minute ping to gradually disseminate our new ENRs to the network. 

Discovery ENR propagation is a slow process anyway, so changing from rapid updates with a small risk of amplification to a slow spread of the ENR could be the more reasonable choice. 
