### PR TITLE
Announce only clear IP winner

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -339,6 +339,12 @@ impl ConfigBuilder {
             self.config.executor = Some(Box::<crate::executor::TokioExecutor>::default());
         };
 
+        // If enr-update is set to false, then it is non-intuitive for discv5 to revoke ENR details
+        // when determining NAT status. So we will not do this.
+        if self.config.enr_update {
+            self.config.auto_nat_listen_duration = None;
+        }
+
         assert!(self.config.incoming_bucket_limit <= MAX_NODES_PER_BUCKET);
 
         self.config.clone()

--- a/src/service/ip_vote.rs
+++ b/src/service/ip_vote.rs
@@ -1,3 +1,25 @@
+//! This struct keeps track of voting for what our external socket is for both IPv4 and IPv6. 
+//!
+//! Without correct SNAT routing rules, some routers can use alternating or round-robin ports to
+//! send outbound traffic. Generally speaking, these ports won't be accessible for inbound traffic
+//! from any peers, so they should not be advertised. 
+//!
+//! Therefore the majority function works as follows:
+//! - Keep track of all votes within a defined time period (vote_duration)
+//! - We count the votes. We consider an IP a majority winner if the following conditions are met:
+//!     - There are more votes than the minimum_threshold (prevents accidentally selecting the
+//!       wrong IP, or having a small group of malicious actors persuade us of the wrong value)
+//!     - There are no other candidates that are also above the threshold or within
+//!       CLEAR_MAJORITY_PERCENTAGE of the
+//!       majority (This prevents multiple candidates from flip-flopping. There should not be 
+//!       competing IP values. If there are, this is a misconfiguration of the network set-up, and 
+//!       we should not advertise an IP. The user can override this via CLI configurations.)
+//!
+//!       The CLEAR_MAJORITY_PERCENTAGE criteria, prevents the case where multiple ports are being cycled, we don't want
+//!       to advertise the first vote that reaches the threshold then switch back to nothing as the
+//!       others catch up. 
+
+
 use enr::NodeId;
 use fnv::FnvHashMap;
 use std::{
@@ -6,6 +28,11 @@ use std::{
     net::{SocketAddr, SocketAddrV4, SocketAddrV6},
     time::{Duration, Instant},
 };
+use tracing::debug;
+
+/// To avoid false winners, the majority vote win by at least this percentage compared to the next
+/// likely candidate.
+const CLEAR_MAJORITY_PERCENTAGE:f64 = 0.2; 
 
 /// A collection of IP:Ports for our node reported from external peers.
 pub(crate) struct IpVote {
@@ -46,13 +73,17 @@ impl IpVote {
         }
     }
 
-    /// Returns true if we have more than the minimum number of non-expired votes for a given ip
-    /// version.
-    pub fn has_minimum_threshold(&mut self) -> (bool, bool) {
+    /// Explicit pruning of old states in the hashamp.
+    fn clear_old_votes(&mut self) {
         let instant = Instant::now();
         self.ipv4_votes.retain(|_, v| v.1 > instant);
         self.ipv6_votes.retain(|_, v| v.1 > instant);
+    }
 
+    /// Returns true if we have more than the minimum number of non-expired votes for a given ip
+    /// version.
+    pub fn has_minimum_threshold(&mut self) -> (bool, bool) {
+        self.clear_old_votes();
         (
             self.ipv4_votes.len() >= self.minimum_threshold,
             self.ipv6_votes.len() >= self.minimum_threshold,
@@ -60,18 +91,22 @@ impl IpVote {
     }
 
     /// Filter the stale votes and return the majority `SocketAddr` if it exists.
+    /// If there are two candidates that both exceed the minimum_threshold, this will return None.
+    /// If the second highest candidate is within 20% of the highest, we also return None.
     /// If there are not enough votes to meet the threshold this returns None.
-    fn filter_stale_find_most_frequent<K: Copy + Eq + Hash>(
+    fn filter_stale_find_most_frequent<K: Copy + Eq + Hash + std::fmt::Debug>(
         votes: &HashMap<NodeId, (K, Instant)>,
         minimum_threshold: usize,
     ) -> (HashMap<NodeId, (K, Instant)>, Option<K>) {
         let mut updated = HashMap::default();
         let mut counter: FnvHashMap<K, usize> = FnvHashMap::default();
-        let mut max: Option<(K, usize)> = None;
+        let mut max_count = 0;
+        let mut second_max_count = 0;
+        let mut max_vote = None;
         let now = Instant::now();
 
         for (node_id, (vote, instant)) in votes {
-            // Discard stale votes.
+            // Discard stale votes
             if instant <= &now {
                 continue;
             }
@@ -79,22 +114,46 @@ impl IpVote {
 
             let count = counter.entry(*vote).or_default();
             *count += 1;
-            let current_max = max.map(|(_v, m)| m).unwrap_or_default();
-            if *count >= current_max && *count >= minimum_threshold {
-                max = Some((*vote, *count));
+
+            // Update max and second_max in single pass
+            if *count > max_count {
+                // Only update second_max if the previous max was from a different vote
+                if max_vote.is_some() && max_vote != Some(*vote) {
+                    second_max_count = max_count;
+                }
+                max_count = *count;
+                max_vote = Some(*vote);
+            } else if *count > second_max_count && Some(*vote) != max_vote {
+                second_max_count = *count;
             }
         }
 
-        (updated, max.map(|m| m.0))
+        // Check if we have a clear winner
+        let result = if max_count >= minimum_threshold {
+            let threshold = ((max_count as f64) * (1.0 - CLEAR_MAJORITY_PERCENTAGE)).round() as usize;
+            if second_max_count >= threshold {
+                debug!(highest_count = max_count, second_highest_count = second_max_count, 
+                       "Competing votes detected. Socket not updated.");
+                None
+            } else {
+                max_vote
+            }
+        } else {
+            None
+        };
+
+        (updated, result)
     }
 
     /// Returns the majority `SocketAddr`'s of both IPv4 and IPv6 if they exist. If there are not enough votes to meet the threshold this returns None for each stack.
+    // NOTE: This removes stale entries by replacing the hashmaps once filtered.
     pub fn majority(&mut self) -> (Option<SocketAddrV4>, Option<SocketAddrV6>) {
         let (updated_ipv4_votes, ipv4_majority) = Self::filter_stale_find_most_frequent::<
             SocketAddrV4,
         >(
             &self.ipv4_votes, self.minimum_threshold
         );
+        // This removes stale entries.
         self.ipv4_votes = updated_ipv4_votes;
 
         let (updated_ipv6_votes, ipv6_majority) = Self::filter_stale_find_most_frequent::<
@@ -102,6 +161,7 @@ impl IpVote {
         >(
             &self.ipv6_votes, self.minimum_threshold
         );
+        // This removes stale entries.
         self.ipv6_votes = updated_ipv6_votes;
 
         (ipv4_majority, ipv6_majority)
@@ -110,7 +170,8 @@ impl IpVote {
 
 #[cfg(test)]
 mod tests {
-    use super::{Duration, IpVote, NodeId, SocketAddrV4};
+    use super::{Duration, IpVote, NodeId, SocketAddrV4, CLEAR_MAJORITY_PERCENTAGE};
+    use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
 
     #[test]
     fn test_three_way_vote_draw() {
@@ -131,8 +192,8 @@ mod tests {
         votes.insert(NodeId::random(), socket_3);
         votes.insert(NodeId::random(), socket_3);
 
-        // Assert that in a draw situation a majority is still chosen.
-        assert!(votes.majority().0.is_some());
+        // With new logic, draw situations should return None due to competing votes
+        assert!(votes.majority().0.is_none());
     }
 
     #[test]
@@ -163,5 +224,278 @@ mod tests {
         votes.insert(NodeId::random(), socket_3);
 
         assert_eq!(votes.majority(), (None, None));
+    }
+
+    
+    #[test] 
+    fn test_snat_fluctuation_multiple_iterations() {
+        // Demonstrates how repeated calls with same data can yield different results
+        // simulating real-world SNAT fluctuation scenarios
+        
+        let ip = "10.0.0.1".parse().unwrap();
+        let port_1 = SocketAddrV4::new(ip, 50000);
+        let port_2 = SocketAddrV4::new(ip, 50001);
+        
+        let mut results = Vec::new();
+        
+        // Run multiple iterations with alternating vote insertion order
+        for iteration in 0..10 {
+            let mut votes = IpVote::new(2, Duration::from_secs(10));
+            
+            if iteration % 2 == 0 {
+                // Even iterations: port_1 votes first
+                for _ in 0..3 {
+                    votes.insert(NodeId::random(), port_1);
+                }
+                for _ in 0..3 {
+                    votes.insert(NodeId::random(), port_2);
+                }
+            } else {
+                // Odd iterations: port_2 votes first  
+                for _ in 0..3 {
+                    votes.insert(NodeId::random(), port_2);
+                }
+                for _ in 0..3 {
+                    votes.insert(NodeId::random(), port_1);
+                }
+            }
+            
+            let result = votes.majority().0;
+            results.push(result);
+        }
+        
+        // Count how many times each port was selected
+        let port_1_wins = results.iter().filter(|r| **r == Some(port_1)).count();
+        let port_2_wins = results.iter().filter(|r| **r == Some(port_2)).count();
+        
+        println!("Port 1 wins: {}, Port 2 wins: {}", port_1_wins, port_2_wins);
+        println!("Results: {:?}", results);
+        
+        // We expect no winner when there are competing ports.
+        assert!(port_1_wins == 0 && port_2_wins == 0, 
+                "Expected both ports to win some iterations due to flip-flop behavior, but got port_1: {}, port_2: {}", 
+                port_1_wins, port_2_wins);
+    }
+
+    // Property-based test structures
+    #[derive(Debug, Clone)]
+    struct VoteData {
+        port: u16,
+        node_id: NodeId,
+    }
+
+    impl Arbitrary for VoteData {
+        fn arbitrary<G: Gen>(g: &mut G) -> VoteData {
+            VoteData {
+                port: u16::arbitrary(g),
+                node_id: NodeId::random(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct VoteScenario {
+        votes: Vec<VoteData>,
+        threshold: usize,
+    }
+
+    impl Arbitrary for VoteScenario {
+        fn arbitrary<G: Gen>(g: &mut G) -> VoteScenario {
+            let threshold = (u8::arbitrary(g) % 10 + 2) as usize; // 2-11
+            let vote_count = (u8::arbitrary(g) % 20) as usize; // 0-19
+            let votes = (0..vote_count).map(|_| VoteData::arbitrary(g)).collect();
+            VoteScenario { votes, threshold }
+        }
+    }
+
+    quickcheck! {
+        /// Property: If no vote meets minimum threshold, result should be None
+        fn prop_below_threshold_returns_none(scenario: VoteScenario) -> TestResult {
+            if scenario.votes.is_empty() {
+                return TestResult::discard();
+            }
+
+            let mut vote_system = IpVote::new(scenario.threshold, Duration::from_secs(10));
+            let ip = "192.168.1.1".parse().unwrap();
+
+            // Add all votes
+            for vote_data in &scenario.votes {
+                let socket = SocketAddrV4::new(ip, vote_data.port);
+                vote_system.insert(vote_data.node_id, socket);
+            }
+
+            // Count votes per port
+            let mut port_counts = std::collections::HashMap::new();
+            for vote_data in &scenario.votes {
+                *port_counts.entry(vote_data.port).or_insert(0) += 1;
+            }
+
+            let max_count = port_counts.values().max().copied().unwrap_or(0);
+
+            if max_count < scenario.threshold {
+                TestResult::from_bool(vote_system.majority().0.is_none())
+            } else {
+                TestResult::discard()
+            }
+        }
+
+        /// Property: If there's a clear winner (>= threshold, >= 20% margin), it should win
+        fn prop_clear_winner_selected(scenario: VoteScenario) -> TestResult {
+            if scenario.votes.len() < 2 {
+                return TestResult::discard();
+            }
+
+            let mut vote_system = IpVote::new(scenario.threshold, Duration::from_secs(10));
+            let ip = "192.168.1.1".parse().unwrap();
+
+            // Add votes
+            for vote_data in &scenario.votes {
+                let socket = SocketAddrV4::new(ip, vote_data.port);
+                vote_system.insert(vote_data.node_id, socket);
+            }
+
+            // Count votes per port
+            let mut port_counts = std::collections::HashMap::new();
+            for vote_data in &scenario.votes {
+                *port_counts.entry(vote_data.port).or_insert(0) += 1;
+            }
+
+            // Find max and second max
+            let mut counts: Vec<_> = port_counts.values().copied().collect();
+            counts.sort_by(|a, b| b.cmp(a));
+            
+            if counts.is_empty() {
+                return TestResult::discard();
+            }
+
+            let max_count = counts[0];
+            let second_max = counts.get(1).copied().unwrap_or(0);
+
+            // Check if we have a clear winner
+            let threshold_margin = ((max_count as f64) * (1.0 - CLEAR_MAJORITY_PERCENTAGE)).round() as usize;
+            let has_clear_winner = max_count >= scenario.threshold && second_max < threshold_margin;
+
+            let result = vote_system.majority().0;
+
+            if has_clear_winner {
+                // Should return the winning port
+                TestResult::from_bool(result.is_some())
+            } else if max_count >= scenario.threshold && second_max >= threshold_margin {
+                // Should return None due to competition
+                TestResult::from_bool(result.is_none())
+            } else {
+                // Below threshold, should be None
+                TestResult::from_bool(result.is_none())
+            }
+        }
+
+        /// Property: Adding the same vote multiple times should be idempotent
+        fn prop_same_vote_idempotent(port: u16) -> bool {
+            let mut vote_system = IpVote::new(2, Duration::from_secs(10));
+            let ip = "192.168.1.1".parse().unwrap();
+            let socket = SocketAddrV4::new(ip, port);
+            let node_id = NodeId::random();
+
+            // Add same vote multiple times
+            vote_system.insert(node_id, socket);
+            let result1 = vote_system.majority().0;
+
+            vote_system.insert(node_id, socket);
+            let result2 = vote_system.majority().0;
+
+            result1 == result2
+        }
+
+        /// Property: Vote count should never exceed number of unique node IDs
+        fn prop_vote_count_bounded_by_nodes() -> bool {
+            let mut vote_system = IpVote::new(2, Duration::from_secs(10));
+            let ip = "192.168.1.1".parse().unwrap();
+            let socket = SocketAddrV4::new(ip, 8080);
+
+            // Add votes from 3 different nodes
+            let nodes = [NodeId::random(), NodeId::random(), NodeId::random()];
+            for &node_id in &nodes {
+                vote_system.insert(node_id, socket);
+            }
+
+            // The implementation should count each node only once
+            // With threshold=2 and 3 votes, should return Some
+            vote_system.majority().0.is_some()
+        }
+    }
+
+    #[test]
+    fn test_exact_threshold_boundary() {
+        let mut votes = IpVote::new(3, Duration::from_secs(10));
+        let ip = "192.168.1.1".parse().unwrap();
+        let socket1 = SocketAddrV4::new(ip, 8080);
+        let socket2 = SocketAddrV4::new(ip, 8081);
+
+        // Add exactly threshold votes for one port
+        for _ in 0..3 {
+            votes.insert(NodeId::random(), socket1);
+        }
+        // Add 1 vote for another port
+        votes.insert(NodeId::random(), socket2);
+
+        // Should return socket1 (3 votes vs 1 vote, clear majority)
+        assert_eq!(votes.majority().0, Some(socket1));
+    }
+
+    #[test]
+    fn test_competing_votes_within_margin() {
+        let mut votes = IpVote::new(2, Duration::from_secs(10));
+        let ip = "192.168.1.1".parse().unwrap();
+        let socket1 = SocketAddrV4::new(ip, 8080);
+        let socket2 = SocketAddrV4::new(ip, 8081);
+
+        // 10 votes for socket1, 9 votes for socket2
+        // 9 >= (10 * 0.8) = 8, so within margin - should return None
+        for _ in 0..10 {
+            votes.insert(NodeId::random(), socket1);
+        }
+        for _ in 0..9 {
+            votes.insert(NodeId::random(), socket2);
+        }
+
+        assert_eq!(votes.majority().0, None);
+    }
+
+    #[test]
+    fn test_clear_majority_outside_margin() {
+        let mut votes = IpVote::new(2, Duration::from_secs(10));
+        let ip = "192.168.1.1".parse().unwrap();
+        let socket1 = SocketAddrV4::new(ip, 8080);
+        let socket2 = SocketAddrV4::new(ip, 8081);
+
+        // 10 votes for socket1, 7 votes for socket2
+        // 7 < (10 * 0.8) = 8, so outside margin - should return socket1
+        for _ in 0..10 {
+            votes.insert(NodeId::random(), socket1);
+        }
+        for _ in 0..7 {
+            votes.insert(NodeId::random(), socket2);
+        }
+
+        assert_eq!(votes.majority().0, Some(socket1));
+    }
+
+    #[test]
+    fn test_three_way_competition() {
+        let mut votes = IpVote::new(2, Duration::from_secs(10));
+        let ip = "192.168.1.1".parse().unwrap();
+        let socket1 = SocketAddrV4::new(ip, 8080);
+        let socket2 = SocketAddrV4::new(ip, 8081);
+        let socket3 = SocketAddrV4::new(ip, 8082);
+
+        // 5 votes each - all within margin of each other
+        for _ in 0..5 {
+            votes.insert(NodeId::random(), socket1);
+            votes.insert(NodeId::random(), socket2);
+            votes.insert(NodeId::random(), socket3);
+        }
+
+        // Should return None due to competition
+        assert_eq!(votes.majority().0, None);
     }
 }


### PR DESCRIPTION
## Description

Routers have a wide variety of mechanisms for routing behind a NAT. When sending traffic, some can use random source ports, some can round-robin between a variety of ports. In the cases where a router uses a handful of mapped ports to send traffic from, the PONG responses from our peers can indicate a handful of candidates that could be our reachable external address. 

In general, if there are multiple candidates for our true external contactable address, then this likely means that none of them are actually contactable, rather the SNAT configuration of the router hasn't been configured correctly. Any peer trying to contact us from these multiple competing ports, will likely to fail (Symmetric NAT'ing). 

Therefore, this PR adjusts the logic behind choosing what is a viable external contactable address. 

The following conditions must now be met:
- Enough votes for the socket that meet or exceed the minimum vote threshold
- The winning socket must exceed the next highest competitor by at least 20%. 

The idea here is to ignore scenarios where there are multiple competing sockets as these all are likely invalid.

