### PR TITLE
Add cargo deny on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,15 @@ jobs:
       run: cargo install cargo-udeps --locked --force
     - name: Run cargo udeps to identify unused crates in the dependency graph
       run: cargo +nightly udeps --tests --all-targets --release
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    needs: cargo-fmt
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest version of stable rust
+        run: rustup update stable
+      - name: Install cargo-deny
+        run: cargo install --locked cargo-deny
+      - name: Run cargo deny
+        run: cargo deny bans sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny
       - name: Run cargo deny
-        run: cargo deny bans sources
+        run: cargo deny check bans sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hex = "0.4"
 fnv = "1"
 arrayvec = "0.7"
 rand = { version = "0.8", package = "rand" }
-socket2 = "0.5"
+socket2 = "0.6"
 smallvec = "1"
 parking_lot = "0.12"
 lazy_static = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,13 @@
+# cargo-deny configuration for sigp/discv5
+# See https://embarkstudios.github.io/cargo-deny/
+
+[bans]
+multiple-versions = "warn"
+deny = [
+    { crate = "aes", deny-multiple-versions = true, reason = "takes a long time to compile" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

- Add `cargo deny` on CI
- Resolves duplicate `socket2` versions in dependency tree

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

There is still a [duplicate version warning for `windows-sys`](https://github.com/sigp/discv5/actions/runs/21010700885/job/60404607655?pr=295#step:5:5), which will be resolved by https://github.com/rust-lang/socket2/pull/621.

Since `multiple-versions = "warn"`, CI only emits warnings and still passes. Therefore, this PR can be merged as-is.


## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
