### PR TITLE
fix: validate request ID length in Message::decode()

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -357,7 +357,7 @@ impl Message {
         }
 
         let id_bytes = Bytes::decode(payload)?;
-        let id = RequestId(id_bytes.to_vec());
+        let id = RequestId::decode(id_bytes.to_vec())?;
 
         let message = match msg_type {
             1 => {
@@ -857,6 +857,29 @@ mod tests {
         let encoded_message = message.clone().encode();
         assert_eq!(encoded_message.clone(), expected_output);
         assert_eq!(Message::decode(&encoded_message).unwrap(), message);
+    }
+
+    #[test]
+    fn reject_oversized_request_id() {
+        // A PING request with a 9-byte request ID should be rejected.
+        // The discv5 spec limits request IDs to a maximum of 8 bytes.
+        let id = RequestId(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]); // 9 bytes
+        let request = Request {
+            id,
+            body: RequestBody::Ping { enr_seq: 1 },
+        };
+        let encoded = request.encode();
+        Message::decode(&encoded).expect_err("should reject request ID longer than 8 bytes");
+
+        // An 8-byte request ID should be accepted.
+        let id = RequestId(vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        let request = Message::Request(Request {
+            id,
+            body: RequestBody::Ping { enr_seq: 1 },
+        });
+        let encoded = request.clone().encode();
+        let decoded = Message::decode(&encoded).expect("8-byte request ID should be valid");
+        assert_eq!(request, decoded);
     }
 
     #[test]


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

`Message::decode()` was constructing RequestId directly from decoded bytes without validating the length. [The discv5 spec limits request IDs to a maximum of 8 bytes](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#protocol-messages): 

> The first element of every message-data list is the request ID. request-id is an RLP byte array of length <= 8 bytes. For requests, this value is assigned by the requester. The recipient of a message must mirror the value in the request-id element of the response. The selection of appropriate values for request IDs is left to the implementation.


This caused the node to accept and echo back oversized request IDs (e.g. 9 bytes) in PONG responses, which violates the spec. The node should silently drop messages with invalid request IDs.

Fixes the hive devp2p PingLargeRequestID conformance test.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [ ] Self-review
- [ ] Documentation updates if relevant
- [x] Tests if relevant
