### PR TITLE
Fix clippy errors

### DIFF
--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -90,8 +90,8 @@ impl<TNodeId, TVal: Eq> PendingNode<TNodeId, TVal> {
         self.node.status
     }
 
-    pub fn value_mut(&mut self) -> &mut TVal {
-        &mut self.node.value
+    pub fn value(&self) -> &TVal {
+        &self.node.value
     }
 
     pub fn set_ready_at(&mut self, t: Instant) {

--- a/src/kbucket/entry.rs
+++ b/src/kbucket/entry.rs
@@ -175,12 +175,12 @@ where
     }
 
     /// Returns the value associated with the key.
-    pub fn value(&mut self) -> &mut TVal {
+    pub fn value(&self) -> &TVal {
         self.0
             .bucket
-            .pending_mut()
+            .pending()
             .expect("We can only build a ConnectedPendingEntry if the entry is pending; QED")
-            .value_mut()
+            .value()
     }
 
     /// Updates the status of the pending entry.

--- a/src/query_pool/peers/closest.rs
+++ b/src/query_pool/peers/closest.rs
@@ -324,8 +324,8 @@ where
     /// Consumes the query, returning the target and the closest peers.
     pub fn into_result(self) -> Vec<TNodeId> {
         self.closest_peers
-            .into_iter()
-            .filter_map(|(_, peer)| {
+            .into_values()
+            .filter_map(|peer| {
                 if let QueryPeerState::Succeeded = peer.state {
                     Some(peer.key.into_preimage())
                 } else {

--- a/src/query_pool/peers/predicate.rs
+++ b/src/query_pool/peers/predicate.rs
@@ -314,8 +314,8 @@ where
     /// Consumes the query, returning the peers who match the predicate.
     pub fn into_result(self) -> Vec<TNodeId> {
         self.closest_peers
-            .into_iter()
-            .filter_map(|(_, peer)| {
+            .into_values()
+            .filter_map(|peer| {
                 if let QueryPeerState::Succeeded = peer.state {
                     if peer.predicate_match {
                         Some(peer.key.into_preimage())

--- a/src/service.rs
+++ b/src/service.rs
@@ -1293,10 +1293,8 @@ impl Service {
                     kbucket::Entry::Present(entry, _) if entry.value().seq() < enr.seq() => {
                         entry.remove()
                     }
-                    kbucket::Entry::Pending(entry, _) => {
-                        if entry.value().seq() < enr.seq() {
-                            entry.remove()
-                        }
+                    kbucket::Entry::Pending(entry, _) if entry.value().seq() < enr.seq() => {
+                        entry.remove()
                     }
                     _ => {}
                 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -616,11 +616,9 @@ impl Service {
                 // check if we need to update the known ENR
                 let mut to_request_enr = None;
                 match self.kbuckets.write().entry(&node_address.node_id.into()) {
-                    kbucket::Entry::Present(ref mut entry, _) => {
-                        if entry.value().seq() < enr_seq {
-                            let enr = entry.value().clone();
-                            to_request_enr = Some(enr);
-                        }
+                    kbucket::Entry::Present(ref entry, _) if entry.value().seq() < enr_seq => {
+                        let enr = entry.value().clone();
+                        to_request_enr = Some(enr);
                     }
                     kbucket::Entry::Pending(ref mut entry, _) => {
                         if entry.value().seq() < enr_seq {

--- a/src/service.rs
+++ b/src/service.rs
@@ -620,11 +620,9 @@ impl Service {
                         let enr = entry.value().clone();
                         to_request_enr = Some(enr);
                     }
-                    kbucket::Entry::Pending(ref mut entry, _) => {
-                        if entry.value().seq() < enr_seq {
-                            let enr = entry.value().clone();
-                            to_request_enr = Some(enr);
-                        }
+                    kbucket::Entry::Pending(ref entry, _) if entry.value().seq() < enr_seq => {
+                        let enr = entry.value().clone();
+                        to_request_enr = Some(enr);
                     }
                     // don't know the peer, don't request its most recent ENR
                     _ => {}
@@ -1274,7 +1272,7 @@ impl Service {
 
                 let must_update_enr = match self.kbuckets.write().entry(&key) {
                     kbucket::Entry::Present(entry, _) => entry.value().seq() < enr.seq(),
-                    kbucket::Entry::Pending(mut entry, _) => entry.value().seq() < enr.seq(),
+                    kbucket::Entry::Pending(entry, _) => entry.value().seq() < enr.seq(),
                     _ => false,
                 };
 
@@ -1295,7 +1293,7 @@ impl Service {
                     kbucket::Entry::Present(entry, _) if entry.value().seq() < enr.seq() => {
                         entry.remove()
                     }
-                    kbucket::Entry::Pending(mut entry, _) => {
+                    kbucket::Entry::Pending(entry, _) => {
                         if entry.value().seq() < enr.seq() {
                             entry.remove()
                         }


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

This PR fixes the following clippy errors:
- https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#iter_kv_map
- https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#collapsible_match

It also removes unnecessary `mut` usages in:
- 3a6f723f37435e05c1f7cce2f818ae910048408e
- b13cb7c793bbfc0db2a6606a5224fdc10688d719 

Note: in b13cb7c793bbfc0db2a6606a5224fdc10688d719,  changed `PendingNode::value()` and `PendingEntry::value()` were updated to avoid requiring mutable access unnecessarily. Previously, the following code caused a compilation error at service.rs:623:

```rust
kbucket::Entry::Pending(ref entry, _) if entry.value().seq() < enr_seq => {
//                                       ^^^^^ cannot borrow immutable local variable `entry` as mutable
    let enr = entry.value().clone();
    to_request_enr = Some(enr);
}
```


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [x] Self-review
- [x] Documentation updates if relevant
- [x] Tests if relevant
