### PR TITLE
fix: restore `&mut` APIs for `PendingEntry`

### DIFF
--- a/src/kbucket/bucket.rs
+++ b/src/kbucket/bucket.rs
@@ -94,6 +94,10 @@ impl<TNodeId, TVal: Eq> PendingNode<TNodeId, TVal> {
         &self.node.value
     }
 
+    pub fn value_mut(&mut self) -> &mut TVal {
+        &mut self.node.value
+    }
+
     pub fn set_ready_at(&mut self, t: Instant) {
         self.replace = t;
     }

--- a/src/kbucket/entry.rs
+++ b/src/kbucket/entry.rs
@@ -183,6 +183,14 @@ where
             .value()
     }
 
+    pub fn value_mut(&mut self) -> &mut TVal {
+        self.0
+            .bucket
+            .pending_mut()
+            .expect("We can only build a ConnectedPendingEntry if the entry is pending; QED")
+            .value_mut()
+    }
+
     /// Updates the status of the pending entry.
     pub fn update(self, status: NodeStatus) -> PendingEntry<'a, TPeerId, TVal> {
         self.0.bucket.update_pending(status);


### PR DESCRIPTION
## Description

https://github.com/sigp/discv5/pull/301 removed APIs exposing mutable access to value of `PendingEntry`

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->

## Change checklist

- [ ] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
