### PR TITLE
Version bump to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discv5"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
-version = "0.10.4"
+version = "0.11.0"
 description = "Implementation of the p2p discv5 discovery protocol"
 license = "Apache-2.0"
 repository = "https://github.com/sigp/discv5"


### PR DESCRIPTION
## Description

<!--
A summary of what this pull request achieves and a rough list of changes.
-->

Bump the minor version since recent changes include breaking changes.

#### Breaking Changes

- Reduced public API surface ([#304](https://github.com/ackintosh/discv5/pull/304))

#### New Features

- Add escape hatch for fallback decoding ([#299](https://github.com/ackintosh/discv5/pull/299))

#### Bug Fixes

- Fix `ipv4_contactable` / `ipv6_contactable` metrics never updated ([#300](https://github.com/ackintosh/discv5/pull/300))
- Validate request ID length in `Message::decode()` ([#296](https://github.com/ackintosh/discv5/pull/296))
- Remove expected-response entry on challenge expiry ([#306](https://github.com/ackintosh/discv5/pull/306))



## Notes & open questions

TODOs for maintainers after this PR is merged:

* Publish a new release on GitHub
* Publish a new crate version to crates.io

<!--
Any notes, remarks or open questions you have to make about the PR. Feel free to remove this section if it's unnecessary 
-->
<!--
## Change checklist

- [ ] Self-review
- [ ] Documentation updates if relevant
- [ ] Tests if relevant
-->